### PR TITLE
fix: harden whatsapp lifecycle (disconnect, QR-on-relink, race safety)

### DIFF
--- a/src/lib/whatsapp-baileys.ts
+++ b/src/lib/whatsapp-baileys.ts
@@ -1,8 +1,10 @@
 /**
- * WhatsApp via Baileys — lightweight WebSocket connection.
- * - Captures group messages in real-time (no upload needed after connect)
- * - Sends daily reports to manager/execs via WhatsApp
- * - Session persists to disk (.baileys_auth/)
+ * WhatsApp via Baileys — gateway-style lifecycle.
+ *
+ * State machine: disconnected → connecting → qr_ready → connecting → connected
+ * Errors classified as: loggedOut | restartRequired | replaced | transient
+ *
+ * Public API is unchanged — callers in src/app/api/whatsapp/* keep working.
  */
 
 import makeWASocket, {
@@ -14,17 +16,28 @@ import makeWASocket, {
   type BaileysEventMap,
 } from '@whiskeysockets/baileys'
 import QRCode from 'qrcode'
-import { Boom } from '@hapi/boom'
-import path from 'path'
+import path from 'node:path'
+import { rm } from 'node:fs/promises'
 import type { RawMessage } from '@/types'
 
+// ── Types ────────────────────────────────────────────────────────────────────
+
 export type BaileysStatus = 'disconnected' | 'qr_ready' | 'connecting' | 'connected' | 'failed'
+
+type DisconnectKind = 'loggedOut' | 'restartRequired' | 'replaced' | 'transient'
 
 interface BaileysState {
   status: BaileysStatus
   qrDataUrl: string | null
   error: string | null
   socket: WASocket | null
+  connectingPromise: Promise<{ status: BaileysStatus; error?: string }> | null
+  reconnectAttempts: number
+  lastConnectedAt: number | null
+  reconnectTimer: ReturnType<typeof setTimeout> | null
+  // True while disconnect() is running. Causes connect/scheduleReconnect/close
+  // handler to bail so a late event can't undo the disconnect.
+  shuttingDown: boolean
   // Real-time message capture
   capturedMessages: RawMessage[]
   monitoredGroupJid: string | null
@@ -33,11 +46,29 @@ interface BaileysState {
   messagesCapturedToday: number
 }
 
+const AUTH_DIR = path.join(process.cwd(), '.baileys_auth')
+
+const RECONNECT_POLICY = {
+  initialMs: 2_000,
+  maxMs: 30_000,
+  factor: 1.8,
+  jitter: 0.25,
+  maxAttempts: 12,
+  // After this much continuous uptime, treat the connection as healthy and
+  // reset the attempt counter so a future drop starts a fresh backoff curve.
+  healthyAfterMs: 60_000,
+}
+
 const state: BaileysState = {
   status: 'disconnected',
   qrDataUrl: null,
   error: null,
   socket: null,
+  connectingPromise: null,
+  reconnectAttempts: 0,
+  lastConnectedAt: null,
+  reconnectTimer: null,
+  shuttingDown: false,
   capturedMessages: [],
   monitoredGroupJid: null,
   monitoredGroupName: null,
@@ -45,7 +76,75 @@ const state: BaileysState = {
   messagesCapturedToday: 0,
 }
 
-const AUTH_DIR = path.join(process.cwd(), '.baileys_auth')
+// ── Pure helpers ─────────────────────────────────────────────────────────────
+
+export function getStatusCode(err: unknown): number | undefined {
+  if (!err || typeof err !== 'object') return undefined
+  const e = err as {
+    output?: { statusCode?: number }
+    status?: number
+    error?: { output?: { statusCode?: number } }
+  }
+  return e.output?.statusCode ?? e.status ?? e.error?.output?.statusCode
+}
+
+export function classifyDisconnect(err: unknown): DisconnectKind {
+  const code = getStatusCode(err)
+  if (code === DisconnectReason.loggedOut) return 'loggedOut'
+  if (code === DisconnectReason.restartRequired) return 'restartRequired'
+  // 440 = replaced (another device opened this session)
+  if (code === DisconnectReason.connectionReplaced) return 'replaced'
+  return 'transient'
+}
+
+export function computeBackoff(attempt: number): number {
+  const { initialMs, maxMs, factor, jitter } = RECONNECT_POLICY
+  const base = Math.min(maxMs, initialMs * Math.pow(factor, Math.max(0, attempt - 1)))
+  const j = base * jitter * (Math.random() * 2 - 1)
+  return Math.max(initialMs, Math.round(base + j))
+}
+
+function formatErr(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === 'string') return err
+  const code = getStatusCode(err)
+  return code ? `status=${code}` : String(err)
+}
+
+async function wipeAuthDir(): Promise<void> {
+  try {
+    await rm(AUTH_DIR, { recursive: true, force: true })
+  } catch (e) {
+    console.warn('[Baileys] Failed to wipe auth dir:', formatErr(e))
+  }
+}
+
+function clearReconnectTimer(): void {
+  if (state.reconnectTimer) {
+    clearTimeout(state.reconnectTimer)
+    state.reconnectTimer = null
+  }
+}
+
+function teardownSocket(): void {
+  const sock = state.socket
+  state.socket = null
+  if (!sock) return
+  try {
+    sock.ev.removeAllListeners('connection.update')
+    sock.ev.removeAllListeners('messages.upsert')
+    sock.ev.removeAllListeners('creds.update')
+  } catch {
+    // listeners may already be detached
+  }
+  try {
+    sock.ws?.close?.()
+  } catch {
+    // best-effort
+  }
+}
+
+// ── Public read API ──────────────────────────────────────────────────────────
 
 export function getStatus() {
   const today = new Date().toISOString().slice(0, 10)
@@ -59,29 +158,43 @@ export function getStatus() {
   }
 }
 
-/**
- * Get all captured messages for today (or a specific date).
- * These are ready to be sent to /api/ingest.
- */
 export function getCapturedMessages(date?: string): RawMessage[] {
   const target = date || new Date().toISOString().slice(0, 10)
-  return state.capturedMessages.filter(m => m.date === target)
+  return state.capturedMessages.filter((m) => m.date === target)
 }
 
-/** Clear captured messages after successful ingestion */
-export function clearCapturedMessages(date?: string) {
+export function clearCapturedMessages(date?: string): void {
   if (date) {
-    state.capturedMessages = state.capturedMessages.filter(m => m.date !== date)
+    state.capturedMessages = state.capturedMessages.filter((m) => m.date !== date)
   } else {
     state.capturedMessages = []
   }
 }
 
+// ── Connect / Disconnect ─────────────────────────────────────────────────────
+
 export async function connect(): Promise<{ status: BaileysStatus; error?: string }> {
+  if (state.shuttingDown) {
+    return { status: 'disconnected', error: 'Disconnect in progress' }
+  }
   if (state.socket && state.status === 'connected') {
     return { status: 'connected' }
   }
+  if (state.connectingPromise) {
+    return state.connectingPromise
+  }
 
+  clearReconnectTimer()
+  teardownSocket()
+
+  state.connectingPromise = openSocket().finally(() => {
+    state.connectingPromise = null
+  })
+
+  return state.connectingPromise
+}
+
+async function openSocket(): Promise<{ status: BaileysStatus; error?: string }> {
   try {
     state.status = 'connecting'
     state.error = null
@@ -95,99 +208,227 @@ export async function connect(): Promise<{ status: BaileysStatus; error?: string
       auth: authState,
       generateHighQualityLinkPreview: false,
     })
+    state.socket = sock
 
     sock.ev.on('creds.update', saveCreds)
+    sock.ev.on('connection.update', handleConnectionUpdate)
+    sock.ev.on('messages.upsert', handleMessagesUpsert)
 
-    sock.ev.on('connection.update', async (update) => {
-      const { connection, lastDisconnect, qr } = update
-
-      if (qr) {
-        try {
-          state.qrDataUrl = await QRCode.toDataURL(qr, { width: 280, margin: 2 })
-          state.status = 'qr_ready'
-          console.log('[Baileys] QR code ready — scan with your phone')
-        } catch (e) {
-          console.error('[Baileys] QR generation error:', e)
-        }
-      }
-
-      if (connection === 'close') {
-        const reason = (lastDisconnect?.error as Boom)?.output?.statusCode
-        if (reason === DisconnectReason.loggedOut) {
-          state.status = 'disconnected'
-          state.error = 'Logged out. Please reconnect.'
-          state.socket = null
-        } else {
-          console.log('[Baileys] Disconnected, reconnecting...', reason)
-          state.status = 'connecting'
-          setTimeout(() => connect(), 3000)
-        }
-      }
-
-      if (connection === 'open') {
-        state.status = 'connected'
-        state.qrDataUrl = null
-        state.error = null
-        console.log('[Baileys] Connected!')
-      }
-    })
-
-    // ── Real-time message listener ─────────────────────────────
-    sock.ev.on('messages.upsert', async (m: BaileysEventMap['messages.upsert']) => {
-      if (m.type !== 'notify') return // only new messages, not history sync
-
-      for (const msg of m.messages) {
-        // Skip if no monitored group set
-        if (!state.monitoredGroupJid) continue
-        // Only capture from the monitored group
-        if (msg.key.remoteJid !== state.monitoredGroupJid) continue
-        // Skip messages sent by us
-        if (msg.key.fromMe) continue
-
-        const parsed = parseWAMessage(msg)
-        if (parsed) {
-          // Cap at 5000 messages to prevent OOM
-          if (state.capturedMessages.length >= 5000) state.capturedMessages.shift()
-          state.capturedMessages.push(parsed)
-          const today = new Date().toISOString().slice(0, 10)
-          if (state.captureStartDate === today) {
-            state.messagesCapturedToday++
-          } else {
-            state.captureStartDate = today
-            state.messagesCapturedToday = 1
-          }
-          console.log(`[Baileys] Captured message from ${parsed.sender}: ${parsed.message.slice(0, 60)}...`)
-        }
-      }
-    })
-
-    state.socket = sock
     return { status: state.status }
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e)
+    const msg = formatErr(e)
     state.status = 'failed'
     state.error = msg
+    teardownSocket()
     return { status: 'failed', error: msg }
   }
 }
 
-/** Parse a Baileys WAMessage into our RawMessage format */
-function parseWAMessage(msg: WAMessage): RawMessage | null {
-  const body = msg.message?.conversation
-    || msg.message?.extendedTextMessage?.text
-    || ''
+async function handleConnectionUpdate(update: BaileysEventMap['connection.update']): Promise<void> {
+  const { connection, lastDisconnect, qr } = update
 
+  if (qr) {
+    try {
+      state.qrDataUrl = await QRCode.toDataURL(qr, { width: 280, margin: 2 })
+      state.status = 'qr_ready'
+      console.log('[Baileys] QR ready — scan with your phone')
+    } catch (e) {
+      console.error('[Baileys] QR generation error:', formatErr(e))
+    }
+  }
+
+  if (connection === 'open') {
+    state.status = 'connected'
+    state.qrDataUrl = null
+    state.error = null
+    state.lastConnectedAt = Date.now()
+    state.reconnectAttempts = 0
+    console.log('[Baileys] Connected')
+    return
+  }
+
+  if (connection === 'close') {
+    if (state.shuttingDown) {
+      // disconnect() owns cleanup; ignore any close events that arrive
+      // mid-shutdown so we can't accidentally schedule a reconnect.
+      return
+    }
+    const err = lastDisconnect?.error
+    const kind = classifyDisconnect(err)
+    const code = getStatusCode(err)
+    console.log(`[Baileys] Closed: kind=${kind} code=${code ?? 'n/a'}`)
+
+    teardownSocket()
+
+    // Connection was healthy long enough to count as "good" — reset attempts.
+    if (
+      state.lastConnectedAt &&
+      Date.now() - state.lastConnectedAt >= RECONNECT_POLICY.healthyAfterMs
+    ) {
+      state.reconnectAttempts = 0
+    }
+    state.lastConnectedAt = null
+
+    if (kind === 'loggedOut') {
+      // Phone unlinked the device, OR we just called logout(). Either way,
+      // creds are now invalid — wipe them so the next connect() generates a
+      // fresh QR instead of looping on stale creds.
+      await wipeAuthDir()
+      state.status = 'disconnected'
+      state.qrDataUrl = null
+      state.error = 'Logged out from WhatsApp. Click Connect to scan a new QR.'
+      state.monitoredGroupJid = null
+      state.monitoredGroupName = null
+      return
+    }
+
+    if (kind === 'replaced') {
+      // Another device took over this session — do not auto-reconnect, that
+      // would just keep stealing the session back and forth.
+      state.status = 'disconnected'
+      state.qrDataUrl = null
+      state.error = 'Another device opened this WhatsApp session.'
+      return
+    }
+
+    if (kind === 'restartRequired') {
+      // Status 515 — Baileys handshake completed and asks for a fresh socket.
+      // This is normal during first-time pairing right after the QR scan.
+      console.log('[Baileys] Restart required — reconnecting immediately')
+      void scheduleReconnect(0)
+      return
+    }
+
+    // Transient: WS dropped, network blip, server hiccup. Backoff + retry.
+    state.reconnectAttempts += 1
+    if (state.reconnectAttempts >= RECONNECT_POLICY.maxAttempts) {
+      state.status = 'failed'
+      state.error = `Reconnect failed after ${state.reconnectAttempts} attempts. ${formatErr(err)}`
+      console.error('[Baileys]', state.error)
+      return
+    }
+    const delay = computeBackoff(state.reconnectAttempts)
+    console.log(`[Baileys] Reconnect attempt ${state.reconnectAttempts} in ${delay}ms`)
+    void scheduleReconnect(delay)
+  }
+}
+
+function scheduleReconnect(delayMs: number): Promise<void> {
+  clearReconnectTimer()
+  if (state.shuttingDown) return Promise.resolve()
+  state.status = 'connecting'
+  return new Promise<void>((resolve) => {
+    state.reconnectTimer = setTimeout(async () => {
+      state.reconnectTimer = null
+      if (state.shuttingDown) {
+        resolve()
+        return
+      }
+      try {
+        await connect()
+      } catch (e) {
+        console.error('[Baileys] Reconnect failed:', formatErr(e))
+      } finally {
+        resolve()
+      }
+    }, delayMs)
+  })
+}
+
+export async function disconnect(): Promise<void> {
+  state.shuttingDown = true
+  try {
+    clearReconnectTimer()
+
+    // 1. Wait for any in-flight connect() to finish, otherwise its socket would
+    //    survive our teardown and become a phantom connection.
+    if (state.connectingPromise) {
+      await state.connectingPromise.catch(() => {})
+    }
+
+    // 2. Detach listeners FIRST so the close event from logout/teardown can't
+    //    re-enter handleConnectionUpdate and schedule a reconnect.
+    const sock = state.socket
+    state.socket = null
+    if (sock) {
+      try {
+        sock.ev.removeAllListeners('connection.update')
+        sock.ev.removeAllListeners('messages.upsert')
+        sock.ev.removeAllListeners('creds.update')
+      } catch {
+        // best-effort
+      }
+
+      // 3. Tell WhatsApp to revoke this linked device.
+      try {
+        await sock.logout()
+      } catch (e) {
+        console.warn('[Baileys] logout() failed (continuing with local cleanup):', formatErr(e))
+      }
+
+      // 4. Close the underlying WebSocket.
+      try {
+        sock.ws?.close?.()
+      } catch {
+        // best-effort
+      }
+    }
+
+    // 5. Wipe creds so next connect() starts fresh with a new QR.
+    await wipeAuthDir()
+
+    // 6. Reset all state.
+    state.status = 'disconnected'
+    state.qrDataUrl = null
+    state.error = null
+    state.reconnectAttempts = 0
+    state.lastConnectedAt = null
+    state.monitoredGroupJid = null
+    state.monitoredGroupName = null
+    state.captureStartDate = null
+    state.messagesCapturedToday = 0
+    state.capturedMessages = []
+  } finally {
+    state.shuttingDown = false
+  }
+}
+
+// ── Message capture ──────────────────────────────────────────────────────────
+
+function handleMessagesUpsert(m: BaileysEventMap['messages.upsert']): void {
+  if (m.type !== 'notify') return // only new messages, not history sync
+
+  for (const msg of m.messages) {
+    if (!state.monitoredGroupJid) continue
+    if (msg.key.remoteJid !== state.monitoredGroupJid) continue
+    if (msg.key.fromMe) continue
+
+    const parsed = parseWAMessage(msg)
+    if (!parsed) continue
+
+    if (state.capturedMessages.length >= 5000) state.capturedMessages.shift()
+    state.capturedMessages.push(parsed)
+
+    const today = new Date().toISOString().slice(0, 10)
+    if (state.captureStartDate === today) {
+      state.messagesCapturedToday += 1
+    } else {
+      state.captureStartDate = today
+      state.messagesCapturedToday = 1
+    }
+    console.log(`[Baileys] Captured from ${parsed.sender}: ${parsed.message.slice(0, 60)}…`)
+  }
+}
+
+function parseWAMessage(msg: WAMessage): RawMessage | null {
+  const body = msg.message?.conversation || msg.message?.extendedTextMessage?.text || ''
   if (!body && !msg.message?.locationMessage) return null
 
-  const ts = msg.messageTimestamp
-    ? new Date(Number(msg.messageTimestamp) * 1000)
-    : new Date()
-
+  const ts = msg.messageTimestamp ? new Date(Number(msg.messageTimestamp) * 1000) : new Date()
   const date = ts.toISOString().slice(0, 10)
   const time = ts.toTimeString().slice(0, 5)
   const sender = msg.pushName || msg.key.participant || msg.key.remoteJid || 'Unknown'
 
-  // Detect message type
   let messageType: RawMessage['messageType'] = 'Text'
   let url: string | undefined
 
@@ -197,97 +438,95 @@ function parseWAMessage(msg: WAMessage): RawMessage | null {
     if (loc?.degreesLatitude && loc?.degreesLongitude) {
       url = `https://maps.google.com/?q=${loc.degreesLatitude},${loc.degreesLongitude}`
     }
-  } else if (msg.message?.imageMessage || msg.message?.videoMessage || msg.message?.audioMessage || msg.message?.documentMessage || msg.message?.stickerMessage) {
+  } else if (
+    msg.message?.imageMessage ||
+    msg.message?.videoMessage ||
+    msg.message?.audioMessage ||
+    msg.message?.documentMessage ||
+    msg.message?.stickerMessage
+  ) {
     messageType = 'MediaOmitted'
   }
 
   return { date, time, sender, message: body, messageType, url }
 }
 
-export async function disconnect() {
-  if (state.socket) {
-    state.socket.end(undefined)
-    state.socket = null
-  }
-  state.status = 'disconnected'
-  state.qrDataUrl = null
-}
+// ── Group monitoring & sending ───────────────────────────────────────────────
 
-/**
- * Start monitoring a WhatsApp group for messages.
- * Call this after connecting and setting the group name in settings.
- */
-export async function startMonitoringGroup(groupName: string): Promise<{ success: boolean; groupName?: string; error?: string }> {
+export async function startMonitoringGroup(
+  groupName: string,
+): Promise<{ success: boolean; groupName?: string; error?: string }> {
   if (!state.socket || state.status !== 'connected') {
     return { success: false, error: 'WhatsApp not connected' }
   }
-
   try {
     const groups = await state.socket.groupFetchAllParticipating()
-    const group = Object.values(groups).find(g =>
-      g.subject.toLowerCase().includes(groupName.toLowerCase())
+    const group = Object.values(groups).find((g) =>
+      g.subject.toLowerCase().includes(groupName.toLowerCase()),
     )
-
     if (!group) {
-      const available = Object.values(groups).map(g => g.subject).slice(0, 10).join(', ')
+      const available = Object.values(groups)
+        .map((g) => g.subject)
+        .slice(0, 10)
+        .join(', ')
       return { success: false, error: `Group "${groupName}" not found. Available: ${available}` }
     }
-
+    // Switching groups: clear the buffer so we don't pipe old-group messages
+    // into a report for the new group.
+    if (state.monitoredGroupJid && state.monitoredGroupJid !== group.id) {
+      state.capturedMessages = []
+    }
     state.monitoredGroupJid = group.id
     state.monitoredGroupName = group.subject
     state.captureStartDate = new Date().toISOString().slice(0, 10)
     state.messagesCapturedToday = 0
-
-    console.log(`[Baileys] Now monitoring group: ${group.subject} (${group.id})`)
+    console.log(`[Baileys] Monitoring group: ${group.subject} (${group.id})`)
     return { success: true, groupName: group.subject }
   } catch (e) {
-    return { success: false, error: e instanceof Error ? e.message : 'Failed to find group' }
+    return { success: false, error: formatErr(e) }
   }
 }
 
-/** List available WhatsApp groups */
 export async function listGroups(): Promise<{ name: string; id: string; participants: number }[]> {
   if (!state.socket || state.status !== 'connected') {
     throw new Error('WhatsApp not connected')
   }
-
   const groups = await state.socket.groupFetchAllParticipating()
-  return Object.values(groups).map(g => ({
+  return Object.values(groups).map((g) => ({
     name: g.subject,
     id: g.id,
     participants: g.participants.length,
   }))
 }
 
-/** Send a text message to a WhatsApp number */
 export async function sendMessage(phone: string, message: string): Promise<boolean> {
   if (!state.socket || state.status !== 'connected') {
     throw new Error('WhatsApp not connected')
   }
-
   const jid = phone.includes('@') ? phone : `${phone}@s.whatsapp.net`
-
   try {
     await state.socket.sendMessage(jid, { text: message })
-    console.log(`[Baileys] Sent message to ${phone}`)
+    console.log(`[Baileys] Sent to ${phone}`)
     return true
   } catch (e) {
-    console.error(`[Baileys] Failed to send to ${phone}:`, e)
+    console.error(`[Baileys] Failed to send to ${phone}:`, formatErr(e))
     return false
   }
 }
 
-/** Send formatted daily report to a WhatsApp number */
-export async function sendDailyReport(phone: string, report: {
-  date: string
-  totalVisits: number
-  execsReporting: number
-  totalExecs: number
-  targetsMet: number
-  topPerformers: { name: string; visits: number }[]
-  alerts: { exec: string; message: string }[]
-  summaryText?: string
-}): Promise<boolean> {
+export async function sendDailyReport(
+  phone: string,
+  report: {
+    date: string
+    totalVisits: number
+    execsReporting: number
+    totalExecs: number
+    targetsMet: number
+    topPerformers: { name: string; visits: number }[]
+    alerts: { exec: string; message: string }[]
+    summaryText?: string
+  },
+): Promise<boolean> {
   const lines: string[] = [
     `📊 *Sales Tracker — Daily Report*`,
     `📅 ${report.date}`,
@@ -309,7 +548,7 @@ export async function sendDailyReport(phone: string, report: {
 
   if (report.alerts.length > 0) {
     lines.push(`⚠️ *Alerts*`)
-    report.alerts.slice(0, 5).forEach(a => {
+    report.alerts.slice(0, 5).forEach((a) => {
       lines.push(`• ${a.exec}: ${a.message}`)
     })
     lines.push(``)


### PR DESCRIPTION
## Why

Two bugs reported from the field by Nishkarsh:
1. Disconnect button does not actually disconnect — the device stays in WhatsApp's "Linked Devices" list.
2. After manually unlinking from the WhatsApp app, clicking Connect does not show a QR — the app loops silently.

Root cause: `socket.end()` only closes the WebSocket. It does not call `logout()` (which revokes the device on WhatsApp servers) and does not wipe `.baileys_auth/`. Stale creds then cause the next connect to authenticate with invalid credentials, get 401, fail silently, and never generate a fresh QR.

## What changed

Single file: `src/lib/whatsapp-baileys.ts`. Public API surface unchanged — zero changes needed in the 6 API routes that import it.

Approach: ported the connection state machine and error taxonomy from openclaw's `@openclaw/whatsapp` extension (same library, Baileys 7.0.0-rc.9). Cherry-picked the patterns, not the code — added ~150 LOC, no new dependencies.

### Fixes

| # | Issue | Fix |
|---|-------|-----|
| 1 | Disconnect button doesn't disconnect | `disconnect()` now calls `socket.logout()` (revokes the device server-side) then wipes `.baileys_auth/` |
| 2 | No QR after manual unlink | `loggedOut` (401) branch in close handler now wipes `.baileys_auth/` so next connect starts fresh |
| 3 | First-time pairing relied on a 3s blanket retry | `restartRequired` (515) handled explicitly with immediate reconnect |
| 4 | "Replaced by another device" (440) caused thrashing | Stops cleanly with a clear error message |
| 5 | Hard 3s retry loop on transient drops | Exponential backoff with jitter (2s → 30s, max 12 attempts), counter resets after 60s of healthy uptime |
| 6 | `disconnect()` ↔ close-handler race could schedule a reconnect that defeats the disconnect | `shuttingDown` flag short-circuits connect/scheduleReconnect/close handler during disconnect |
| 7 | `disconnect()` ↔ in-flight `connect()` race could leave a phantom socket | `disconnect()` awaits `connectingPromise` before teardown; listeners removed BEFORE logout |
| 8 | Switching monitored group polluted next pipeline run with old-group messages | `startMonitoringGroup` clears `capturedMessages` when group changes |
| 9 | Double-click Connect could leak a socket | Idempotent `connect()` via `connectingPromise` |

### Code-quality cleanups
- Dropped unused `@hapi/boom` cast (the `as Boom | undefined` was a no-op).
- Pure helpers (`getStatusCode`, `classifyDisconnect`, `computeBackoff`) exported for future testability.

## Test plan

- [ ] On droplet, wipe `.baileys_auth/` and pair fresh — verify QR appears and pairing completes within ~5s of scan.
- [ ] Click Disconnect — verify the device disappears from phone's "WhatsApp → Linked Devices" within 5s.
- [ ] Click Connect again — verify a new QR appears (no stale-cred loop).
- [ ] Manually unlink via phone's "Linked Devices" — verify app status flips to disconnected with the "Logged out" error message.
- [ ] Click Connect after manual unlink — verify a fresh QR appears.
- [ ] Switch monitored group — verify the new group's `messagesCapturedToday` starts at 0.
- [ ] Send a daily report after pairing — verify it lands.