### PR TITLE
fix: field-team feedback + close unauth hole (Apr 23)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,11 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD:-changeme}
     volumes:
       - pgdata:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
+    # NOTE: deliberately NOT publishing 5432 to the host. The `app` service
+    # reaches `db` on Docker's internal network via `db:5432`. Publishing
+    # would expose Postgres to the public internet if the host firewall is
+    # ever misconfigured. If you need direct DB access, use
+    # `docker compose exec db psql ...` or port-forward via SSH tunnel.
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,3 +1,9 @@
+// Schema change log:
+// 2026-04-17 — Added rawTextHash (String?, @map("raw_text_hash")) to Visit and
+//              unique constraint @@unique([executiveId, visitDate, rawTextHash], name: "uniq_exec_day_text")
+//              to prevent duplicate rows when the pipeline re-processes the same messages.
+//              Deployed via `prisma db push` (no formal migration file needed — see docker-compose.yml:44).
+
 generator client {
   provider = "prisma-client-js"
 }
@@ -50,6 +56,7 @@ model Visit {
   schoolId      String?  @map("school_id")
   visitDate     DateTime @map("visit_date") @db.Date
   rawText       String?  @map("raw_text")
+  rawTextHash   String?  @map("raw_text_hash") // md5[:16] of rawText; used for dedup unique constraint
 
   // Extracted fields
   schoolNameRaw    String?  @map("school_name_raw")
@@ -84,6 +91,7 @@ model Visit {
   school    School?   @relation(fields: [schoolId], references: [id])
   alerts    Alert[]
 
+  @@unique([executiveId, visitDate, rawTextHash], name: "uniq_exec_day_text")
   @@index([executiveId, visitDate])
   @@index([schoolId])
   @@index([visitDate])

--- a/scripts/cleanup-fake-execs.sql
+++ b/scripts/cleanup-fake-execs.sql
@@ -1,0 +1,47 @@
+-- scripts/cleanup-fake-execs.sql
+--
+-- One-shot cleanup for executives that were auto-created from WhatsApp JIDs
+-- (group JIDs "*@g.us", individual JIDs "*@s.whatsapp.net", or "Unknown").
+--
+-- Run AFTER deploying the fix branch so the bug doesn't re-introduce them.
+--
+-- Usage on the droplet:
+--   docker compose exec db psql -U postgres -d sales_tracker -f /scripts/cleanup-fake-execs.sql
+-- or, from an interactive psql:
+--   \i /scripts/cleanup-fake-execs.sql
+--
+-- Idempotent: safe to run repeatedly.
+
+BEGIN;
+
+-- 1) Collect the fake exec IDs into a temp table for cascade operations.
+CREATE TEMP TABLE _fake_execs AS
+SELECT id, display_name
+FROM   executives
+WHERE  display_name LIKE '%@g.us'
+   OR  display_name LIKE '%@s.whatsapp.net'
+   OR  display_name LIKE '%@broadcast'
+   OR  display_name LIKE '%@newsletter'
+   OR  display_name = 'Unknown';
+
+-- Show what we're about to delete so you can sanity-check before COMMIT.
+\echo 'Fake executives about to be purged:'
+SELECT id, display_name FROM _fake_execs ORDER BY display_name;
+
+-- 2) Purge dependent rows first (no FK cascade configured).
+DELETE FROM alerts WHERE executive_id IN (SELECT id FROM _fake_execs);
+DELETE FROM visits WHERE executive_id IN (SELECT id FROM _fake_execs);
+
+-- 3) Purge the fake execs themselves.
+DELETE FROM executives WHERE id IN (SELECT id FROM _fake_execs);
+
+-- 4) Show what remains.
+\echo 'Remaining active executives:'
+SELECT id, display_name, daily_target, active
+FROM   executives
+WHERE  active = TRUE
+ORDER  BY display_name;
+
+-- Inspect the output above. If it looks wrong, run ROLLBACK;
+-- If it looks right, run COMMIT;
+-- (Script intentionally does NOT auto-commit.)

--- a/src/app/api/reports/[date]/excel/route.ts
+++ b/src/app/api/reports/[date]/excel/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { generateDailyReportExcel } from '@/lib/pipeline/excel-export'
+import { generateDailyReportExcelFromDb } from '@/lib/pipeline/excel-export'
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
 
@@ -48,7 +48,7 @@ export async function GET(
       },
     })
 
-    const buffer = await generateDailyReportExcel(visits as any, date)
+    const buffer = await generateDailyReportExcelFromDb(visits, date)
 
     return new Response(new Uint8Array(buffer), {
       status: 200,

--- a/src/app/team/[id]/page.tsx
+++ b/src/app/team/[id]/page.tsx
@@ -2,9 +2,39 @@
 
 import { useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
-import { format, parseISO } from 'date-fns'
+import { format, parseISO, addDays } from 'date-fns'
 import { Mail, RefreshCw, AlertTriangle } from 'lucide-react'
 
+// ── API response shape (matches /api/executives/[id]) ────────
+interface ApiResponse {
+  executive: {
+    id: string
+    displayName: string
+    email?: string | null
+    dailyTarget: number
+  }
+  weeklyPerformance: {
+    weekStart: string
+    weekEnd: string
+    dailyVisits: number[]   // length 6: Mon[0]…Sat[5]
+    totalVisits: number
+    weeklyTarget: number
+    targetMet: boolean
+    newSchools: number
+    samplingCount: number
+    meetingCount: number
+  }
+  thisWeekVisits: {
+    id: string
+    visitDate: string
+    schoolNameRaw: string | null
+    dataComplete: boolean
+    missingFields: string[]
+    school: { id: string; canonicalName: string } | null
+  }[]
+}
+
+// ── Derived UI types ──────────────────────────────────────────
 interface DailyVisit {
   date: string
   count: number
@@ -25,19 +55,43 @@ interface MissingData {
   fields: string[]
 }
 
-interface ExecutiveData {
-  id: string
-  displayName: string
-  dailyVisits: DailyVisit[]
-  stats: ExecStats
-  missingData: MissingData[]
+// ── Helpers ───────────────────────────────────────────────────
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+function safeFormatDate(raw: string, fmt: string, fallback: string): string {
+  try {
+    const d = parseISO(raw)
+    if (isNaN(d.getTime())) return fallback
+    return format(d, fmt)
+  } catch {
+    return fallback
+  }
 }
 
+function buildDailyVisits(weekStart: string, counts: number[]): DailyVisit[] {
+  // weekStart is a YYYY-MM-DD string (Monday of this week)
+  return counts.slice(0, 6).map((count, idx) => {
+    try {
+      const base = parseISO(weekStart)
+      if (isNaN(base.getTime())) throw new Error('invalid')
+      const day = addDays(base, idx)
+      return {
+        date: format(day, 'yyyy-MM-dd'),
+        count,
+        label: DAY_LABELS[idx] ?? String(idx),
+      }
+    } catch {
+      return { date: `day-${idx}`, count, label: DAY_LABELS[idx] ?? String(idx) }
+    }
+  })
+}
+
+// ── Page component ────────────────────────────────────────────
 export default function TeamPage() {
   const params = useParams()
   const id = typeof params.id === 'string' ? params.id : ''
 
-  const [data, setData] = useState<ExecutiveData | null>(null)
+  const [apiData, setApiData] = useState<ApiResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -49,8 +103,8 @@ export default function TeamPage() {
         setError(null)
         const res = await fetch(`/api/executives/${id}`)
         if (!res.ok) throw new Error('Failed to load executive data')
-        const json = await res.json()
-        setData(json)
+        const json: ApiResponse = await res.json()
+        setApiData(json)
       } catch (e) {
         setError(e instanceof Error ? e.message : 'Unknown error')
       } finally {
@@ -76,9 +130,32 @@ export default function TeamPage() {
     )
   }
 
-  if (!data) return null
+  if (!apiData) return null
 
-  const { dailyVisits, stats } = data
+  const { executive, weeklyPerformance, thisWeekVisits } = apiData
+
+  // Derive UI values from the API response
+  const dailyVisits: DailyVisit[] = buildDailyVisits(
+    weeklyPerformance.weekStart,
+    weeklyPerformance.dailyVisits
+  )
+
+  const stats: ExecStats = {
+    weekTotal:     weeklyPerformance.totalVisits,
+    target:        weeklyPerformance.weeklyTarget,
+    newSchools:    weeklyPerformance.newSchools,
+    samplingCount: weeklyPerformance.samplingCount,
+    meetingCount:  weeklyPerformance.meetingCount,
+  }
+
+  const missingData: MissingData[] = thisWeekVisits
+    .filter((v) => !v.dataComplete)
+    .map((v) => ({
+      date:   v.visitDate,
+      school: v.school?.canonicalName ?? v.schoolNameRaw ?? '(unknown)',
+      fields: v.missingFields,
+    }))
+
   const maxVisits = Math.max(...dailyVisits.map((d) => d.count), 1)
   const targetMet = stats.weekTotal >= stats.target
 
@@ -86,7 +163,7 @@ export default function TeamPage() {
     <div className="py-5 space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-zinc-50">{data.displayName}</h1>
+        <h1 className="text-2xl font-bold text-zinc-50">{executive.displayName}</h1>
         <p className="text-sm text-zinc-500 mt-0.5">Weekly Performance</p>
       </div>
 
@@ -146,13 +223,13 @@ export default function TeamPage() {
       </div>
 
       {/* Missing data */}
-      {data.missingData && data.missingData.length > 0 && (
+      {missingData.length > 0 && (
         <div>
           <h2 className="text-xs font-bold uppercase tracking-widest text-zinc-500 mb-2">
             Incomplete Records
           </h2>
           <div className="space-y-2">
-            {data.missingData.map((item, i) => (
+            {missingData.map((item, i) => (
               <div
                 key={i}
                 className="bg-amber-950 border border-amber-500 rounded-lg px-3 py-2.5 flex items-start gap-2"
@@ -161,7 +238,7 @@ export default function TeamPage() {
                 <div>
                   <p className="text-xs font-semibold text-amber-400">{item.school}</p>
                   <p className="text-xs text-amber-400 mt-0.5 opacity-70">
-                    {format(parseISO(item.date), 'd MMM')} · Missing: {item.fields.join(', ')}
+                    {safeFormatDate(item.date, 'd MMM', item.date)} · Missing: {item.fields.join(', ')}
                   </p>
                 </div>
               </div>
@@ -173,7 +250,7 @@ export default function TeamPage() {
       {/* Action */}
       <button
         onClick={() => {
-          window.location.href = `mailto:?subject=Weekly Report - ${data.displayName}&body=Please find the weekly sales report attached.`
+          window.location.href = `mailto:?subject=Weekly Report - ${executive.displayName}&body=Please find the weekly sales report attached.`
         }}
         className="w-full flex items-center justify-center gap-2 bg-blue-600 text-zinc-50 rounded-xl py-3.5 text-sm font-semibold transition-colors hover:bg-blue-500"
       >

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -25,13 +25,16 @@ export function startCron() {
     const hour = now.getHours()
     const minute = now.getMinutes()
 
-    // Run at 8:00 PM (20:00)
+    // Run at 8:00 PM (20:00) — container TZ=Asia/Kolkata per docker-compose.yml
     if (hour === 20 && minute === 0) {
-      // Guard: check if we already ran today
-      const today = new Date().toISOString().slice(0, 10)
-      const todayStart = new Date(today + 'T00:00:00Z')
+      // Guard: check if we already ran today. Use local-time date bounds
+      // (not UTC) so the guard window aligns with the operator's day.
+      // TZ=Asia/Kolkata, so toLocaleDateString('en-CA') → YYYY-MM-DD in IST.
+      const localToday = new Date().toLocaleDateString('en-CA') // YYYY-MM-DD in TZ
+      const todayStart = new Date(`${localToday}T00:00:00`)     // local midnight
+      const todayEnd   = new Date(`${localToday}T23:59:59.999`) // local end-of-day
       const existing = await prisma.ingestionRun.findFirst({
-        where: { runDate: { gte: todayStart } },
+        where: { runDate: { gte: todayStart, lte: todayEnd } },
       }).catch(() => null)
       if (existing) {
         console.log('[Cron] Already ran today, skipping')
@@ -53,7 +56,8 @@ export function stopCron() {
 }
 
 async function autoProcess() {
-  const today = new Date().toISOString().slice(0, 10)
+  // Use local (IST) date so today's messages align with the operator's day.
+  const today = new Date().toLocaleDateString('en-CA')
 
   try {
     const { status, monitoredGroup } = getStatus()

--- a/src/lib/pipeline/excel-export.ts
+++ b/src/lib/pipeline/excel-export.ts
@@ -109,6 +109,104 @@ export async function generateDailyReportExcel(
   return Buffer.from(buffer)
 }
 
+// ── DB row shape for the daily report route ──────────────────
+export interface DbVisitRow {
+  id: string
+  visitDate: Date
+  schoolNameRaw: string | null
+  address: string | null
+  board: string | null
+  strength: number | null
+  principalName: string | null
+  principalMobile: string | null
+  principalEmail: string | null
+  principalDob: string | null
+  bookSeller: string | null
+  remark: string | null
+  remarkDetail: string | null
+  locationUrl: string | null
+  dataComplete: boolean
+  missingFields: string[]
+  isRepeatVisit: boolean
+  visitNumberInSession: number
+  executive: { id: string; displayName: string }
+  school: { id: string; canonicalName: string } | null
+}
+
+function formatDetailsFromDb(visit: DbVisitRow): string {
+  const lines = [
+    `Board: ${visit.board ?? '—'}`,
+    `Strength: ${visit.strength ?? '—'}`,
+    `Principal: ${visit.principalName ?? '—'}`,
+    `Mobile No: ${visit.principalMobile ?? '—'}`,
+    `DOB: ${visit.principalDob ?? '—'}`,
+    `Email: ${visit.principalEmail ?? '—'}`,
+    `Book Seller: ${visit.bookSeller ?? '—'}`,
+  ]
+  return lines.join('\n')
+}
+
+// ── 1b. generateDailyReportExcelFromDb ───────────────────────
+// Same output as generateDailyReportExcel but accepts the raw
+// Prisma DB shape (with nested executive + school relations).
+export async function generateDailyReportExcelFromDb(
+  dbVisits: DbVisitRow[],
+  date: string
+): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook()
+  workbook.creator = 'WhatsApp Sales Agent'
+  workbook.created = new Date()
+
+  const sheet = workbook.addWorksheet(`Daily Report ${date}`)
+
+  sheet.columns = [
+    { header: 'Date',          key: 'date',     width: 14 },
+    { header: 'Employee Name', key: 'employee', width: 20 },
+    { header: 'School Name',   key: 'school',   width: 30 },
+    { header: 'Address',       key: 'address',  width: 30 },
+    { header: 'Details',       key: 'details',  width: 40 },
+    { header: 'Remark',        key: 'remark',   width: 30 },
+  ]
+
+  styleHeader(sheet.getRow(1))
+
+  for (const visit of dbVisits) {
+    const visitDateStr =
+      visit.visitDate instanceof Date
+        ? visit.visitDate.toISOString().split('T')[0]
+        : String(visit.visitDate)
+
+    const row = sheet.addRow({
+      date:     visitDateStr,
+      employee: visit.executive.displayName,
+      school:   visit.school?.canonicalName ?? visit.schoolNameRaw ?? '—',
+      address:  visit.address ?? '—',
+      details:  formatDetailsFromDb(visit),
+      remark:   visit.remark
+        ? visit.remarkDetail
+          ? `${visit.remark} — ${visit.remarkDetail}`
+          : visit.remark
+        : '—',
+    })
+
+    row.eachCell((cell, colNumber) => {
+      styleDataCell(cell, colNumber === 5)
+    })
+
+    row.height = 7 * 15
+  }
+
+  sheet.views = [{ state: 'frozen', ySplit: 1 }]
+
+  sheet.autoFilter = {
+    from: { row: 1, column: 1 },
+    to:   { row: 1, column: 6 },
+  }
+
+  const buffer = await workbook.xlsx.writeBuffer()
+  return Buffer.from(buffer)
+}
+
 // ── 2. generateWeeklyReportExcel ─────────────────────────────
 export async function generateWeeklyReportExcel(
   performances: ExecWeeklyPerformance[]

--- a/src/lib/pipeline/orchestrator.ts
+++ b/src/lib/pipeline/orchestrator.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import type {
   RawMessage,
   ValidatedVisit,
@@ -51,6 +52,8 @@ export async function runPipeline(
   const getOrCreateExecId = async (rawName: string): Promise<string | null> => {
     const trimmed = rawName.trim()
     if (!trimmed) return null
+    if (trimmed === 'Unknown') return null
+    if (/@(g\.us|s\.whatsapp\.net|broadcast|newsletter)$/i.test(trimmed)) return null
     const key = trimmed.toLowerCase()
     const cached = execNameToId.get(key)
     if (cached) return cached
@@ -209,12 +212,33 @@ export async function runPipeline(
       const execId = await getOrCreateExecId(chunk.senderNormalized)
 
       if (execId) {
-        await prisma.visit.create({
-          data: {
+        // Stable 16-char hash for dedup; fall back to sentinel when rawText is empty
+        const rawTextHash = createHash('md5')
+          .update(chunk.combinedText || '__no_text__')
+          .digest('hex')
+          .slice(0, 16)
+
+        const visitDate = new Date(`${chunk.date}T00:00:00.000Z`)
+
+        const visitMutableFields = {
+          schoolId: schoolMatchResult.matched ? schoolMatchResult.schoolId : null,
+          remark: extraction.data.remark,
+          remarkDetail: extraction.data.remarkDetail,
+          dataComplete,
+          missingFields: missingFields as any,
+          extractionModel: extraction.model,
+          isRepeatVisit: historyResult.isRepeatVisit,
+          visitNumberInSession: historyResult.visitNumberInSession,
+          changesFromLast: JSON.parse(JSON.stringify(historyResult.changesFromLast)),
+        }
+
+        await prisma.visit.upsert({
+          where: { uniq_exec_day_text: { executiveId: execId, visitDate, rawTextHash } },
+          create: {
             executiveId: execId,
-            schoolId: schoolMatchResult.matched ? schoolMatchResult.schoolId : null,
-            visitDate: new Date(`${chunk.date}T00:00:00.000Z`),
+            visitDate,
             rawText: chunk.combinedText,
+            rawTextHash,
             schoolNameRaw: extraction.data.schoolName,
             address: extraction.data.address,
             board: extraction.data.board,
@@ -224,16 +248,12 @@ export async function runPipeline(
             principalEmail: extraction.data.principalEmail,
             principalDob: extraction.data.principalDob,
             bookSeller: extraction.data.bookSeller,
-            remark: extraction.data.remark,
-            remarkDetail: extraction.data.remarkDetail,
             locationUrl: chunk.locationUrl,
-            dataComplete,
-            missingFields: missingFields as any,
-            extractionModel: extraction.model,
-            isRepeatVisit: historyResult.isRepeatVisit,
-            visitNumberInSession: historyResult.visitNumberInSession,
-            changesFromLast: JSON.parse(JSON.stringify(historyResult.changesFromLast)),
+            ...visitMutableFields,
           },
+          update: visitMutableFields,
+          // NOTE: sheetAppendedAt is intentionally excluded from update to
+          // avoid re-queueing already-synced rows on re-runs.
         })
 
         // Upsert school knowledge if we have enough data
@@ -266,6 +286,19 @@ export async function runPipeline(
     try {
       const execId = await getOrCreateExecId(alert.executiveName)
       if (execId) {
+        // Dedup: skip if an unresolved alert with same (exec, type, message) exists today
+        const today = new Date(`${runDate}T00:00:00.000Z`)
+        const existing = await prisma.alert.findFirst({
+          where: {
+            executiveId: execId,
+            alertType: alert.alertType,
+            message: alert.message,
+            resolved: false,
+            createdAt: { gte: today },
+          },
+        })
+        if (existing) continue
+
         await prisma.alert.create({
           data: {
             executiveId: execId,

--- a/src/lib/whatsapp-baileys.ts
+++ b/src/lib/whatsapp-baileys.ts
@@ -475,6 +475,13 @@ function handleMessagesUpsert(m: BaileysEventMap['messages.upsert']): void {
     const parsed = parseWAMessage(msg)
     if (!parsed) continue
 
+    // Check if this message already exists in the last ~100 entries to avoid dupes
+    // from rapid reconnects or overlapping history sync + live capture
+    const keyOf = (m: RawMessage) => `${m.sender}|${m.date}|${m.time}|${m.message}`
+    const parsedKey = keyOf(parsed)
+    const alreadySeen = state.capturedMessages.slice(-100).some((m) => keyOf(m) === parsedKey)
+    if (alreadySeen) continue
+
     if (state.capturedMessages.length >= 5000) state.capturedMessages.shift()
     state.capturedMessages.push(parsed)
 
@@ -496,7 +503,12 @@ function parseWAMessage(msg: WAMessage): RawMessage | null {
   const ts = msg.messageTimestamp ? new Date(Number(msg.messageTimestamp) * 1000) : new Date()
   const date = ts.toISOString().slice(0, 10)
   const time = ts.toTimeString().slice(0, 5)
-  const sender = msg.pushName || msg.key.participant || msg.key.remoteJid || 'Unknown'
+  // remoteJid is the GROUP's JID in group chats, not an individual.
+  // If pushName and participant are both missing, we have no real human — skip the message.
+  const rawSender = msg.pushName || msg.key.participant
+  if (!rawSender) return null
+  if (/@(g\.us|broadcast|newsletter)$/i.test(rawSender)) return null
+  const sender = rawSender
 
   let messageType: RawMessage['messageType'] = 'Text'
   let url: string | undefined
@@ -558,10 +570,19 @@ export async function startMonitoringGroup(
     // captured queue. Cap at 5000 to match the live-capture limit.
     const historical = state.historicalByJid.get(group.id) ?? []
     if (historical.length > 0) {
-      const combined = [...historical, ...state.capturedMessages]
+      const seen = new Set<string>()
+      const keyOf = (m: RawMessage) => `${m.sender}|${m.date}|${m.time}|${m.message}`
+      const combined: RawMessage[] = []
+      for (const m of [...historical, ...state.capturedMessages]) {
+        const k = keyOf(m)
+        if (seen.has(k)) continue
+        seen.add(k)
+        combined.push(m)
+      }
       state.capturedMessages = combined.slice(-5000)
+      const dupes = historical.length + state.capturedMessages.length - combined.length
       console.log(
-        `[Baileys] Loaded ${historical.length} historical messages for ${group.subject}`,
+        `[Baileys] Loaded ${historical.length} historical messages for ${group.subject} (${dupes} dupes skipped)`,
       )
     }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const PUBLIC_PREFIXES = [
+  "/api/health",
+  "/api/cron/",
+  "/api/sheet-sync/",
+  "/_next/",
+  "/favicon.ico",
+  "/icon.svg",
+];
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const aBytes = new TextEncoder().encode(a);
+  const bBytes = new TextEncoder().encode(b);
+  if (aBytes.length !== bBytes.length) {
+    // Still iterate over a to avoid leaking length via timing
+    let diff = 0;
+    for (let i = 0; i < aBytes.length; i++) {
+      diff |= aBytes[i] ^ (bBytes[i % bBytes.length] ?? 0);
+    }
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < aBytes.length; i++) {
+    diff |= aBytes[i] ^ bBytes[i];
+  }
+  return diff === 0;
+}
+
+export function middleware(req: NextRequest) {
+  const appPassword = process.env.APP_PASSWORD;
+
+  if (!appPassword) {
+    console.warn(
+      "[middleware] APP_PASSWORD is not set — skipping auth (dev mode)"
+    );
+    return NextResponse.next();
+  }
+
+  const pathname = req.nextUrl.pathname;
+
+  const isPublic = PUBLIC_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(prefix)
+  );
+
+  if (isPublic) {
+    return NextResponse.next();
+  }
+
+  const authHeader = req.headers.get("authorization") ?? "";
+  const match = authHeader.match(/^Basic\s+(.+)$/i);
+
+  if (match) {
+    const decoded = Buffer.from(match[1], "base64").toString("utf-8");
+    // Format is "username:password" — we only validate the password portion
+    const colonIndex = decoded.indexOf(":");
+    const password = colonIndex >= 0 ? decoded.slice(colonIndex + 1) : decoded;
+
+    if (timingSafeEqual(password, appPassword)) {
+      return NextResponse.next();
+    }
+  }
+
+  return new NextResponse("Unauthorized", {
+    status: 401,
+    headers: {
+      "WWW-Authenticate": 'Basic realm="Sales Tracker"',
+    },
+  });
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico).*)",
+  ],
+};


### PR DESCRIPTION
## Summary

Addresses the bug reports from Prakhar and Nishkarsh on Apr 23 — blank
Employee/School Name in Excel, team-card click crashes, duplicate rows,
and WhatsApp group JIDs showing up as employees in the dashboard. Also
closes an entire class of unauthenticated-endpoint bugs surfaced during
the full-codebase diagnostic.

## What the field team reported

- *"In the report Excel, Employee Name and School Name are coming up blank"*
- *"After click there, that is occur"* (screenshot showed client-side exception at `/team/120363407918017659-g-us`)
- *"There are double entries as well. Remark column is blank in some rows"*
- *"Duplicacy is there in the sheet. Same message posted once today and the same message posted yesterday. Still showing same date."*

## Root causes found

1. **JID-as-sender fallback** (`whatsapp-baileys.ts:499`). When `pushName` and `participant` were both absent, the code fell back to `remoteJid` — which is the GROUP'S JID in group messages. `getOrCreateExecId` then faithfully auto-created an `Executive` row with that JID as the name.
2. **Excel exporter shape mismatch**. Route passed DB rows into a `ValidatedVisit`-shaped exporter via `as any` → `visit.executiveName` and `visit.schoolName` were always `undefined`.
3. **Team page ≠ Team API**. Page expected `{displayName, dailyVisits: [{date,count,label}], stats, missingData}`; API returned `{executive, weeklyPerformance, thisWeekVisits}`. Every click crashed, not just fake execs.
4. **No dedup on visit writes**. `prisma.visit.create` with no uniqueness → every pipeline re-run duplicates.
5. **History-sync + live-capture buffer merge had no dedup**. Same message landed twice when Baileys delivered it via both `messaging-history.set` and `messages.upsert`.
6. **Every `/api/*` route public** except two cron endpoints. `APP_PASSWORD` env var was declared in `docker-compose.yml` but read nowhere.

## Changes (10 files, 409 / 42)

### Critical fixes

- **`src/middleware.ts`** (new) — HTTP Basic auth using `APP_PASSWORD`, constant-time compare, `WWW-Authenticate: Basic realm="Sales Tracker"`. Allowlists `/api/health`, `/api/cron/*`, `/api/sheet-sync/*` (those check `CRON_SECRET` already).
- **`src/lib/pipeline/excel-export.ts`** — new `generateDailyReportExcelFromDb()` that consumes the actual DB row shape (`visit.executive.displayName`, `visit.school?.canonicalName ?? visit.schoolNameRaw`). Original `generateDailyReportExcel` untouched.
- **`src/app/api/reports/[date]/excel/route.ts`** — swapped to the new exporter; dropped the `as any`.
- **`src/app/team/[id]/page.tsx`** — rewrote to consume `{executive, weeklyPerformance, thisWeekVisits}`; derives Mon-Sat `dailyVisits` from `weekStart`; wraps `parseISO` in safe fallback.
- **`src/lib/whatsapp-baileys.ts`** — rejects `@g.us` / `@broadcast` / `@newsletter` JIDs in `parseWAMessage`; dedups `(sender|date|time|message)` in both `startMonitoringGroup` (history merge) and `handleMessagesUpsert` (live).
- **`src/lib/pipeline/orchestrator.ts`** — three guards in `getOrCreateExecId` (`'Unknown'`, group JIDs, individual JIDs); `prisma.visit.create` → `upsert` keyed on new `uniq_exec_day_text` constraint; alert dedup by `(executiveId, alertType, message, today)`.
- **`prisma/schema.prisma`** — new `rawTextHash` column + `@@unique([executiveId, visitDate, rawTextHash], name: "uniq_exec_day_text")`. Deploys via `prisma db push` on container boot.

### Infra + config

- **`docker-compose.yml`** — removed `ports: "5432:5432"` from the `db` service. Postgres stays on the internal Docker network only.
- **`src/lib/cron.ts`** — "today" and ingestion-run guard bounds computed in local IST via `toLocaleDateString('en-CA')`, not UTC.

### Ops

- **`scripts/cleanup-fake-execs.sql`** — one-shot purge of JID-based fake executives and their visits/alerts. Idempotent, wrapped in `BEGIN;` without auto-commit so you can inspect before committing.

## Deploy sequence

```bash
ssh salestracker
cd sales-agent-publisher
git fetch && git checkout main && git pull
# After merge:
echo "APP_PASSWORD=<choose a strong one>" >> .env
docker compose up -d --build
# Schema auto-migrates via `prisma db push` on container boot.
# Purge fake execs created by the old code:
docker compose cp scripts/cleanup-fake-execs.sql db:/tmp/cleanup.sql
docker compose exec db psql -U postgres -d sales_tracker -f /tmp/cleanup.sql
# Inspect the \echo output; if good:
docker compose exec db psql -U postgres -d sales_tracker -c "COMMIT"
```

## Test plan

- [ ] `/api/health` returns 200 without auth
- [ ] `/api/settings` returns 401 without auth header
- [ ] `/api/settings` returns 200 with correct `Basic :password` header
- [ ] Excel download for today's report has populated Employee Name + School Name columns
- [ ] Team card click on `/` loads `/team/[id]` without "Application error"
- [ ] Week bar chart shows actual Mon-Sat dates, not zeros
- [ ] Pipeline re-run on same `captureStartDate` produces no new visit rows (verify via `SELECT COUNT(*) FROM visits WHERE visit_date = CURRENT_DATE` before + after)
- [ ] No `Executive.display_name LIKE '%@g.us%'` after cleanup SQL runs

## Separate follow-up (out of scope for this PR)

GitHub Action `Nightly Google Sheet Sync` has failed 7 consecutive nights because `APP_URL` and `CRON_SECRET` repo secrets are empty — workflow exits at line 1 before any step runs. Will set those post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)