### PR TITLE
fix: Baileys reliability — disconnect alerts, IST dates, memory caps

### DIFF
--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -1,15 +1,35 @@
 /**
  * App initialization — runs once on server start.
- * Starts the auto-processing cron job.
+ * Starts the auto-processing cron job and wires the Baileys alert callback.
  */
 
 import { startCron } from './cron'
+import { setAlertHandler } from './whatsapp-baileys'
+import { sendAlertEmail } from './email'
+import { prisma } from './db'
 
 let initialized = false
 
 export function initApp() {
   if (initialized) return
   initialized = true
+
+  // Wire Baileys disconnect alerts → email. Keeps whatsapp-baileys.ts
+  // free of db/email imports while ensuring operators get notified.
+  setAlertHandler(async (message) => {
+    try {
+      const settings = await prisma.settings.findUnique({ where: { id: 'default' } })
+      if (settings?.alertEmailTo) {
+        await sendAlertEmail(settings.alertEmailTo, [{
+          type: 'CONNECTION_FAILURE',
+          message,
+          executive: 'System',
+        }])
+      }
+    } catch (e) {
+      console.error('[Init] Baileys alert email failed:', e)
+    }
+  })
 
   startCron()
   console.log('[Init] Sales Tracker started — auto-processing at 8 PM daily')

--- a/src/lib/whatsapp-baileys.ts
+++ b/src/lib/whatsapp-baileys.ts
@@ -53,6 +53,32 @@ interface BaileysState {
 
 const AUTH_DIR = path.join(process.cwd(), '.baileys_auth')
 
+// ── Alert callback (registered by init.ts, keeps this module free of db/email deps) ──
+let alertHandler: ((message: string) => Promise<void> | void) | null = null
+
+export function setAlertHandler(fn: (message: string) => Promise<void> | void): void {
+  alertHandler = fn
+}
+
+export function buildDisconnectAlertMessage(
+  kind: 'loggedOut' | 'replaced' | 'qrTimeout' | 'maxReconnects',
+  attempts?: number
+): string {
+  switch (kind) {
+    case 'loggedOut':     return 'WhatsApp logged out — re-scan QR to reconnect.'
+    case 'replaced':      return 'WhatsApp session replaced by another device.'
+    case 'qrTimeout':     return 'QR not scanned in time — click Connect to generate a new QR.'
+    case 'maxReconnects': return `WhatsApp reconnect failed after ${attempts ?? '?'} attempts — manual reconnect needed.`
+  }
+}
+
+function fireAlert(message: string): void {
+  if (!alertHandler) return
+  Promise.resolve(alertHandler(message)).catch((e) =>
+    console.error('[Baileys] Alert handler failed:', e)
+  )
+}
+
 const RECONNECT_POLICY = {
   initialMs: 2_000,
   maxMs: 30_000,
@@ -303,6 +329,7 @@ async function handleConnectionUpdate(update: BaileysEventMap['connection.update
       state.status = 'disconnected'
       state.qrDataUrl = null
       state.error = 'Logged out from WhatsApp. Click Connect to scan a new QR.'
+      fireAlert(buildDisconnectAlertMessage('loggedOut'))
       state.monitoredGroupJid = null
       state.monitoredGroupName = null
       return
@@ -314,6 +341,7 @@ async function handleConnectionUpdate(update: BaileysEventMap['connection.update
       state.status = 'disconnected'
       state.qrDataUrl = null
       state.error = 'Another device opened this WhatsApp session.'
+      fireAlert(buildDisconnectAlertMessage('replaced'))
       return
     }
 
@@ -332,6 +360,7 @@ async function handleConnectionUpdate(update: BaileysEventMap['connection.update
     if (!wasEverConnected && kind === 'transient') {
       state.status = 'failed'
       state.error = 'QR not scanned in time. Click Connect to generate a new QR.'
+      fireAlert(buildDisconnectAlertMessage('qrTimeout'))
       state.qrDataUrl = null
       console.log('[Baileys] Pairing timed out — user did not scan')
       return
@@ -342,6 +371,7 @@ async function handleConnectionUpdate(update: BaileysEventMap['connection.update
     if (state.reconnectAttempts >= RECONNECT_POLICY.maxAttempts) {
       state.status = 'failed'
       state.error = `Reconnect failed after ${state.reconnectAttempts} attempts. ${formatErr(err)}`
+      fireAlert(buildDisconnectAlertMessage('maxReconnects', state.reconnectAttempts))
       console.error('[Baileys]', state.error)
       return
     }

--- a/src/lib/whatsapp-baileys.ts
+++ b/src/lib/whatsapp-baileys.ts
@@ -531,7 +531,7 @@ function parseWAMessage(msg: WAMessage): RawMessage | null {
   if (!body && !msg.message?.locationMessage) return null
 
   const ts = msg.messageTimestamp ? new Date(Number(msg.messageTimestamp) * 1000) : new Date()
-  const date = ts.toISOString().slice(0, 10)
+  const date = ts.toLocaleDateString('en-CA')
   const time = ts.toTimeString().slice(0, 5)
   // remoteJid is the GROUP's JID in group chats, not an individual.
   // If pushName and participant are both missing, we have no real human — skip the message.

--- a/src/lib/whatsapp-baileys.ts
+++ b/src/lib/whatsapp-baileys.ts
@@ -40,6 +40,7 @@ interface BaileysState {
   shuttingDown: boolean
   // Real-time message capture
   capturedMessages: RawMessage[]
+  capturedMessageKeys: Set<string>
   monitoredGroupJid: string | null
   monitoredGroupName: string | null
   captureStartDate: string | null // YYYY-MM-DD
@@ -75,6 +76,7 @@ const state: BaileysState = {
   reconnectTimer: null,
   shuttingDown: false,
   capturedMessages: [],
+  capturedMessageKeys: new Set(),
   monitoredGroupJid: null,
   monitoredGroupName: null,
   captureStartDate: null,
@@ -85,6 +87,10 @@ const state: BaileysState = {
 }
 
 // ── Pure helpers ─────────────────────────────────────────────────────────────
+
+export function buildMessageKey(m: Pick<RawMessage, 'sender' | 'date' | 'time' | 'message'>): string {
+  return `${m.sender}|${m.date}|${m.time}|${m.message}`
+}
 
 export function getStatusCode(err: unknown): number | undefined {
   if (!err || typeof err !== 'object') return undefined
@@ -185,8 +191,11 @@ export function getCapturedMessages(date?: string): RawMessage[] {
 export function clearCapturedMessages(date?: string): void {
   if (date) {
     state.capturedMessages = state.capturedMessages.filter((m) => m.date !== date)
+    // Rebuild key set to stay in sync with the trimmed buffer
+    state.capturedMessageKeys = new Set(state.capturedMessages.map(buildMessageKey))
   } else {
     state.capturedMessages = []
+    state.capturedMessageKeys = new Set()
   }
 }
 
@@ -426,6 +435,7 @@ export async function disconnect(): Promise<void> {
     state.captureStartDate = null
     state.messagesCapturedToday = 0
     state.capturedMessages = []
+    state.capturedMessageKeys = new Set()
   } finally {
     state.shuttingDown = false
   }
@@ -456,6 +466,7 @@ function handleHistorySet(payload: BaileysEventMap['messaging-history.set']): vo
       bucket = []
       state.historicalByJid.set(jid, bucket)
     }
+    if (bucket.length >= 5000) bucket.shift()
     bucket.push(parsed)
     added++
   }
@@ -475,15 +486,13 @@ function handleMessagesUpsert(m: BaileysEventMap['messages.upsert']): void {
     const parsed = parseWAMessage(msg)
     if (!parsed) continue
 
-    // Check if this message already exists in the last ~100 entries to avoid dupes
-    // from rapid reconnects or overlapping history sync + live capture
-    const keyOf = (m: RawMessage) => `${m.sender}|${m.date}|${m.time}|${m.message}`
+    const keyOf = buildMessageKey
     const parsedKey = keyOf(parsed)
-    const alreadySeen = state.capturedMessages.slice(-100).some((m) => keyOf(m) === parsedKey)
-    if (alreadySeen) continue
+    if (state.capturedMessageKeys.has(parsedKey)) continue
 
     if (state.capturedMessages.length >= 5000) state.capturedMessages.shift()
     state.capturedMessages.push(parsed)
+    state.capturedMessageKeys.add(parsedKey)
 
     const today = new Date().toISOString().slice(0, 10)
     if (state.captureStartDate === today) {
@@ -571,7 +580,7 @@ export async function startMonitoringGroup(
     const historical = state.historicalByJid.get(group.id) ?? []
     if (historical.length > 0) {
       const seen = new Set<string>()
-      const keyOf = (m: RawMessage) => `${m.sender}|${m.date}|${m.time}|${m.message}`
+      const keyOf = buildMessageKey
       const combined: RawMessage[] = []
       for (const m of [...historical, ...state.capturedMessages]) {
         const k = keyOf(m)
@@ -580,6 +589,7 @@ export async function startMonitoringGroup(
         combined.push(m)
       }
       state.capturedMessages = combined.slice(-5000)
+      state.capturedMessageKeys = new Set(state.capturedMessages.map(buildMessageKey))
       const dupes = historical.length + state.capturedMessages.length - combined.length
       console.log(
         `[Baileys] Loaded ${historical.length} historical messages for ${group.subject} (${dupes} dupes skipped)`,

--- a/tests/baileys-dedup-cap.test.ts
+++ b/tests/baileys-dedup-cap.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { buildMessageKey } from '@/lib/whatsapp-baileys'
+import type { RawMessage } from '@/types'
+
+function makeMsg(overrides: Partial<RawMessage> = {}): RawMessage {
+  return {
+    date: '2026-04-30',
+    time: '10:00',
+    sender: 'Sunil',
+    message: 'Carmel Convent CBSE 1800',
+    messageType: 'Text',
+    ...overrides,
+  }
+}
+
+describe('buildMessageKey', () => {
+  it('produces a pipe-delimited key', () => {
+    const m = makeMsg()
+    expect(buildMessageKey(m)).toBe('Sunil|2026-04-30|10:00|Carmel Convent CBSE 1800')
+  })
+
+  it('same message twice produces identical key', () => {
+    const m = makeMsg()
+    expect(buildMessageKey(m)).toBe(buildMessageKey({ ...m }))
+  })
+
+  it('different sender produces different key', () => {
+    expect(buildMessageKey(makeMsg({ sender: 'Ravi' }))).not.toBe(buildMessageKey(makeMsg()))
+  })
+
+  it('different time produces different key', () => {
+    expect(buildMessageKey(makeMsg({ time: '11:00' }))).not.toBe(buildMessageKey(makeMsg()))
+  })
+})
+
+describe('Set-based dedup logic', () => {
+  it('Set catches a duplicate that would fall outside a 100-entry window', () => {
+    const keys = new Set<string>()
+    const first = makeMsg({ message: 'msg-0' })
+    keys.add(buildMessageKey(first))
+
+    // Add 200 more distinct messages
+    for (let i = 1; i <= 200; i++) {
+      keys.add(buildMessageKey(makeMsg({ message: `msg-${i}` })))
+    }
+
+    // first message is still in the Set even though it's > 100 entries ago
+    expect(keys.has(buildMessageKey(first))).toBe(true)
+  })
+})

--- a/tests/baileys-disconnect-alert.test.ts
+++ b/tests/baileys-disconnect-alert.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { buildDisconnectAlertMessage } from '@/lib/whatsapp-baileys'
+
+describe('buildDisconnectAlertMessage', () => {
+  it('loggedOut returns re-scan message', () => {
+    expect(buildDisconnectAlertMessage('loggedOut')).toContain('logged out')
+  })
+
+  it('replaced returns session-replaced message', () => {
+    expect(buildDisconnectAlertMessage('replaced')).toContain('replaced')
+  })
+
+  it('qrTimeout returns QR message', () => {
+    expect(buildDisconnectAlertMessage('qrTimeout')).toContain('QR not scanned')
+  })
+
+  it('maxReconnects includes attempt count', () => {
+    expect(buildDisconnectAlertMessage('maxReconnects', 12)).toContain('12')
+  })
+})

--- a/tests/baileys-message-date.test.ts
+++ b/tests/baileys-message-date.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+
+// Mirrors the date-stamping logic in parseWAMessage (src/lib/whatsapp-baileys.ts).
+// TZ=Asia/Kolkata is set in vitest.config.ts env to match the production container.
+
+describe('message date stamping — IST vs UTC', () => {
+  it('stamps IST date for a message sent at 00:30 IST (19:00 UTC previous day)', () => {
+    // 2026-04-30 00:30 IST = 2026-04-29 19:00:00 UTC
+    const ts = new Date('2026-04-29T19:00:00.000Z')
+    // toISOString gives wrong UTC date
+    expect(ts.toISOString().slice(0, 10)).toBe('2026-04-29')
+    // toLocaleDateString with IST gives correct date
+    expect(ts.toLocaleDateString('en-CA')).toBe('2026-04-30')
+  })
+
+  it('stamps IST date for a message sent at 23:45 IST (18:15 UTC same day)', () => {
+    // 2026-04-30 23:45 IST = 2026-04-30 18:15:00 UTC — both agree
+    const ts = new Date('2026-04-30T18:15:00.000Z')
+    expect(ts.toLocaleDateString('en-CA')).toBe('2026-04-30')
+    expect(ts.toISOString().slice(0, 10)).toBe('2026-04-30')
+  })
+
+  it('time string uses local time (already correct before this fix)', () => {
+    const ts = new Date('2026-04-29T19:00:00.000Z') // = 00:30 IST
+    expect(ts.toTimeString().slice(0, 5)).toBe('00:30')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
     include: ['tests/**/*.test.ts'],
     environment: 'node',
     testTimeout: 10_000,
+    env: { TZ: 'Asia/Kolkata' },
   },
 })


### PR DESCRIPTION
## What this fixes

- **Disconnect alerting**: loggedOut, session replaced, QR timeout, max reconnects now fire an alert email via registered callback — no db/email coupling in whatsapp-baileys.ts
- **IST date stamping**: parseWAMessage used UTC date; messages sent 00:00–05:30 IST were bucketed to previous day. Fixed with toLocaleDateString('en-CA') (TZ=Asia/Kolkata is already set in docker-compose)
- **Set-based dedup**: replaced slice(-100) window check with a persistent Set — catches duplicates anywhere in the 5000-message buffer
- **historicalByJid cap**: full history sync was unbounded in RAM; now capped at 5000/JID matching capturedMessages

## Tests added
- tests/baileys-disconnect-alert.test.ts (4 tests)
- tests/baileys-message-date.test.ts (3 tests)
- tests/baileys-dedup-cap.test.ts (5 tests)

## Test plan
- [ ] `npx vitest run` — all pass
- [ ] `npm run typecheck` — clean
- [ ] Disconnect WhatsApp from phone — verify alert email arrives