### PR TITLE
fix: reliability hardening — P0/P1 gaps from gap analysis

### DIFF
--- a/.github/workflows/health-watch.yml
+++ b/.github/workflows/health-watch.yml
@@ -60,7 +60,7 @@ jobs:
           script: |
             // Grace: require 2 consecutive failures before creating. We
             // implement "second failure" by storing a flag in a repo variable
-            # or by simply creating on first — simpler is fine for v1.
+            // or by simply creating on first — simpler is fine for v1.
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -166,6 +166,7 @@ model Settings {
   sheetSyncEnabled   Boolean @default(false) @map("sheet_sync_enabled")
   lastSheetSyncAt    DateTime? @map("last_sheet_sync_at")
   lastSheetSyncError String?   @map("last_sheet_sync_error")
+  lastWeeklySentAt   DateTime? @map("last_weekly_sent_at")
 
   updatedAt          DateTime @updatedAt @map("updated_at")
 

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -114,7 +114,9 @@ async function autoProcess() {
     }
 
     // Send WhatsApp report to manager
-    if (settings?.managerPhone && /^\+?\d{10,15}$/.test(settings.managerPhone.trim())) {
+    const rawPhone = settings?.managerPhone?.trim() ?? ''
+    const normalizedPhone = rawPhone && /^\d{10}$/.test(rawPhone) ? `+91${rawPhone}` : rawPhone
+    if (normalizedPhone && /^\+\d{11,15}$/.test(normalizedPhone)) {
       const executives = await prisma.executive.findMany({ where: { active: true } })
       const topPerformers = Object.entries(
         result.visits.reduce<Record<string, number>>((acc, v) => {
@@ -124,7 +126,7 @@ async function autoProcess() {
       ).sort(([, a], [, b]) => b - a).slice(0, 5).map(([name, visits]) => ({ name, visits }))
 
       try {
-        await sendDailyReport(settings.managerPhone.trim(), {
+        await sendDailyReport(normalizedPhone, {
           date: today,
           totalVisits: result.summary.totalVisits,
           execsReporting: result.summary.totalExecutivesReporting,
@@ -136,7 +138,7 @@ async function autoProcess() {
         })
         console.log('[Cron] WhatsApp report sent to manager')
       } catch (e) { console.error('[Cron] WhatsApp report failed:', e) }
-    } else if (settings?.managerPhone) {
+    } else if (rawPhone) {
       console.warn('[Cron] managerPhone set but invalid format — WhatsApp report skipped.')
     }
 
@@ -177,7 +179,24 @@ async function autoProcess() {
   }
 }
 
+function getISOWeekKey(d: Date): string {
+  const jan4 = new Date(d.getFullYear(), 0, 4) // Jan 4 is always in week 1
+  const weekNum = Math.ceil(((d.getTime() - jan4.getTime()) / 86400000 + jan4.getDay() + 1) / 7)
+  return `${d.getFullYear()}-W${String(weekNum).padStart(2, '0')}`
+}
+
 async function autoWeekly(): Promise<void> {
+  // Guard: skip if we already ran this ISO week
+  const isoWeekKey = getISOWeekKey(new Date())
+  const lastRan = await prisma.settings.findUnique({ where: { id: 'default' }, select: { lastWeeklySentAt: true } }).catch(() => null)
+  if (lastRan?.lastWeeklySentAt) {
+    const lastKey = getISOWeekKey(lastRan.lastWeeklySentAt)
+    if (lastKey === isoWeekKey) {
+      console.log('[Cron] Weekly summary already sent this week, skipping')
+      return
+    }
+  }
+
   const today = new Date()
   const sunday = new Date(today)
   sunday.setDate(today.getDate() - 1)
@@ -256,6 +275,8 @@ async function autoWeekly(): Promise<void> {
       newSchools,
     })
     console.log(`[Cron] Weekly summary emailed to manager (${summaries.length} execs)`)
+    // Update guard timestamp
+    await prisma.settings.update({ where: { id: 'default' }, data: { lastWeeklySentAt: new Date() } }).catch(() => {})
   } catch (e) {
     console.error('[Cron] Weekly summary email failed:', e)
   }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,5 +1,9 @@
 import { Resend } from 'resend'
 
+function emailFrom(_role: 'alerts' | 'reports'): string {
+  return process.env.EMAIL_FROM ?? 'Sales Tracker <onboarding@resend.dev>'
+}
+
 function getResend() {
   const key = process.env.RESEND_API_KEY
   if (!key) return null
@@ -49,35 +53,7 @@ export async function sendAlertEmail(
 
   const resend = getResend()
   if (!resend) { console.log('[email] RESEND_API_KEY not set, skipping alert email'); return }
-  await resend.emails.send({ from: 'Sales Tracker <alerts@yourdomain.com>', to, subject, html })
-}
-
-export async function sendWeeklyDigest(
-  to: string,
-  summary: { name: string; text: string }[]
-): Promise<void> {
-  const subject = 'Sales Tracker: Weekly Performance Report'
-
-  const cards = summary
-    .map(
-      (s) => `
-        <div style="background:#18181b;border:1px solid #27272a;border-radius:8px;padding:16px;margin-bottom:12px;">
-          <h3 style="color:#f59e0b;margin:0 0 8px;">${esc(s.name)}</h3>
-          <p style="color:#d4d4d8;margin:0;line-height:1.6;">${esc(s.text)}</p>
-        </div>`
-    )
-    .join('')
-
-  const html = `
-    <div style="font-family:sans-serif;background:#09090b;padding:32px;max-width:700px;margin:0 auto;">
-      <h2 style="color:#f59e0b;margin:0 0 8px;">Weekly Performance Report</h2>
-      <p style="color:#a1a1aa;margin:0 0 24px;">Executive summary for the week ending ${todayFormatted()}</p>
-      ${cards}
-    </div>`
-
-  const resend = getResend()
-  if (!resend) { console.log('[email] RESEND_API_KEY not set, skipping email'); return }
-  await resend.emails.send({ from: 'Sales Tracker <reports@yourdomain.com>', to, subject, html })
+  await resend.emails.send({ from: emailFrom('alerts'), to, subject, html })
 }
 
 export async function sendDailySummaryEmail(
@@ -114,7 +90,7 @@ export async function sendDailySummaryEmail(
 
   const resend = getResend()
   if (!resend) { console.log('[email] RESEND_API_KEY not set, skipping email'); return }
-  await resend.emails.send({ from: 'Sales Tracker <reports@yourdomain.com>', to, subject, html })
+  await resend.emails.send({ from: emailFrom('reports'), to, subject, html })
 }
 
 export async function sendWeeklySummaryEmail(
@@ -142,5 +118,5 @@ export async function sendWeeklySummaryEmail(
 
   const resend = getResend()
   if (!resend) { console.log('[email] RESEND_API_KEY not set, skipping weekly summary email'); return }
-  await resend.emails.send({ from: 'Sales Tracker <reports@yourdomain.com>', to, subject, html })
+  await resend.emails.send({ from: emailFrom('reports'), to, subject, html })
 }

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -14,6 +14,17 @@ export function initApp() {
   if (initialized) return
   initialized = true
 
+  // Loud startup warnings for missing production-critical env vars
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('[Init] CRITICAL: ANTHROPIC_API_KEY is not set — AI extraction will fail at 8 PM. Set it in .env and restart.')
+  }
+  if (!process.env.APP_PASSWORD && process.env.NODE_ENV === 'production') {
+    console.error('[Init] CRITICAL: APP_PASSWORD is not set in production — all routes are publicly accessible.')
+  }
+  if (!process.env.RESEND_API_KEY) {
+    console.warn('[Init] WARNING: RESEND_API_KEY is not set — all alert/summary emails will be skipped silently.')
+  }
+
   // Wire Baileys disconnect alerts → email. Keeps whatsapp-baileys.ts
   // free of db/email imports while ensuring operators get notified.
   setAlertHandler(async (message) => {

--- a/src/lib/pipeline/orchestrator.ts
+++ b/src/lib/pipeline/orchestrator.ts
@@ -30,7 +30,7 @@ export async function runPipeline(
   let haikuTokensUsed = 0
   let sonnetTokensUsed = 0
 
-  const runDate = messages[0]?.date ?? new Date().toISOString().substring(0, 10)
+  const runDate = messages[0]?.date ?? new Date().toLocaleDateString('en-CA')
 
   // ── Step 1: Preprocess ──────────────────────────────────────
   const chunks = preprocess(messages)

--- a/src/lib/pipeline/sync-sheet.ts
+++ b/src/lib/pipeline/sync-sheet.ts
@@ -92,10 +92,15 @@ export async function syncPendingVisits(): Promise<SyncResult> {
 
       await appendVisitRows(settings.googleSheetId, tabName, batch)
 
-      await prisma.visit.updateMany({
-        where: { id: { in: batchIds } },
-        data: { sheetAppendedAt: new Date() },
-      })
+      try {
+        await prisma.visit.updateMany({
+          where: { id: { in: batchIds } },
+          data: { sheetAppendedAt: new Date() },
+        })
+      } catch (markErr) {
+        console.error('[sync-sheet] append succeeded but marking failed — next sync will re-append this batch:', markErr)
+        // Continue — don't fail the whole sync for a marking error
+      }
 
       appended += batch.length
     }

--- a/src/lib/whatsapp-baileys.ts
+++ b/src/lib/whatsapp-baileys.ts
@@ -269,7 +269,11 @@ async function openSocket(): Promise<{ status: BaileysStatus; error?: string }> 
     state.socket = sock
 
     sock.ev.on('creds.update', saveCreds)
-    sock.ev.on('connection.update', handleConnectionUpdate)
+    sock.ev.on('connection.update', (update) => {
+      handleConnectionUpdate(update).catch((e) =>
+        console.error('[Baileys] handleConnectionUpdate uncaught error:', e)
+      )
+    })
     sock.ev.on('messages.upsert', handleMessagesUpsert)
     sock.ev.on('messaging-history.set', handleHistorySet)
 
@@ -466,6 +470,9 @@ export async function disconnect(): Promise<void> {
     state.messagesCapturedToday = 0
     state.capturedMessages = []
     state.capturedMessageKeys = new Set()
+    state.historicalByJid = new Map()
+    state.historySyncProgress = 0
+    state.historySyncComplete = false
   } finally {
     state.shuttingDown = false
   }
@@ -500,6 +507,17 @@ function handleHistorySet(payload: BaileysEventMap['messaging-history.set']): vo
     bucket.push(parsed)
     added++
   }
+  // Cap total JID count to prevent unbounded memory growth
+  if (state.historicalByJid.size > 200) {
+    // Remove oldest entries (Map iteration order is insertion order)
+    const toDelete = state.historicalByJid.size - 200
+    let deleted = 0
+    for (const key of state.historicalByJid.keys()) {
+      state.historicalByJid.delete(key)
+      if (++deleted >= toDelete) break
+    }
+  }
+
   console.log(
     `[Baileys] History chunk: +${added} messages across ${state.historicalByJid.size} chats (progress=${state.historySyncProgress}%${isLatest ? ', LATEST' : ''})`,
   )

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,9 +31,10 @@ export function middleware(req: NextRequest) {
   const appPassword = process.env.APP_PASSWORD;
 
   if (!appPassword) {
-    console.warn(
-      "[middleware] APP_PASSWORD is not set — skipping auth (dev mode)"
-    );
+    if (process.env.NODE_ENV === 'production') {
+      return new NextResponse('Service Unavailable: APP_PASSWORD not configured', { status: 503 })
+    }
+    console.warn("[middleware] APP_PASSWORD is not set — skipping auth (dev mode)");
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Fixes

### P0
- **Email sender domain**: all 4 `resend.emails.send()` calls now use `EMAIL_FROM` env var (fallback: `onboarding@resend.dev`). Previously hardcoded `yourdomain.com` rejected by Resend.
- **Startup guards**: loud `console.error` on missing `ANTHROPIC_API_KEY`, `APP_PASSWORD` (prod), `RESEND_API_KEY`

### P1
- **Middleware**: `APP_PASSWORD` missing in production → 503 instead of auth bypass
- **Weekly summary dedup**: `getISOWeekKey` guard prevents double-send on Monday 9 AM server restart. Adds `lastWeeklySentAt` to Settings.
- **Phone normalization**: bare 10-digit `managerPhone` auto-prefixed `+91` before WhatsApp JID construction
- **Baileys async**: `connection.update` listener wrapped in `.catch()` — unhandled rejections were crashing Node 18+
- **runDate IST**: `toISOString()` fallback → `toLocaleDateString('en-CA')` in orchestrator
- **sync-sheet race**: `updateMany` failure after `appendVisitRows` success now logged + continues, not bubbled
- **health-watch YAML**: `#` comment in `github-script` JS block → `//`

### P2
- **historicalByJid**: JID map capped at 200 entries; `disconnect()` now clears `historicalByJid`, `historySyncProgress`, `historySyncComplete`
- **Dead code**: `sendWeeklyDigest` export removed

## Schema migration
`settings` table gains `last_weekly_sent_at TIMESTAMPTZ NULL` — applied automatically by `db push` in docker-compose startup command.

## Test plan
- [ ] `npm run typecheck` — clean
- [ ] `npx vitest run` — all pass
- [ ] `npm run build` — clean
- [ ] Verify `EMAIL_FROM` env var set on droplet before deploy