### PR TITLE
fix: self-healing QR-trap recovery for WhatsApp connect

### DIFF
--- a/CONTINUE.md
+++ b/CONTINUE.md
@@ -1,5 +1,34 @@
 # CONTINUE.md
 
+## 2026-05-05 — QR-trap self-healing fix (PR #39)
+
+### Shipped
+- PR #39 (`fix/qr-trap-loggedout-ebusy`) — three-commit fix for the "click Connect, QR never loads" bug:
+  - `5ba159e` cherry-picked `042e072` (EBUSY retry on `wipeAuthDir` — was on a sibling branch but never merged to main)
+  - `35d3dc3` lib self-heal: `autoRetriedThisSession` flag + auto-retry on `loggedOut` + 10s connect-timeout watchdog
+  - `604b947` UI escape hatch: "Force reset and try again" surfaces after 15s in `connecting`; also fixes poll-interval leak in `handleDisconnect`
+- Diagnosis traced via commit-message grep — `042e072` literally described the symptom; `git merge-base --is-ancestor` confirmed it was missing from main. ~5 min from "QR not loading" to "I know what's wrong."
+- Local gates green: typecheck, 48/48 tests, build. Pre-push hook didn't fire (likely `core.hooksPath` not set in this clone) — same checks ran manually.
+
+### Pending
+- **Watch PR #39 CI** — if `act` gate passes server-side, deploy.yml ships it on merge.
+- **Post-deploy smoke** — hit https://sales.telligences.com/connect, click Connect on the existing stale auth dir, confirm QR appears in ~3s without operator SSH.
+- **Re-pair WhatsApp** once QR loads — same step as before, just the new code makes it work first try.
+
+### Known issues unchanged from 2026-04-23 sprint
+- `APP_PASSWORD` rotation still pending — leaked in transcript, live for 12+ days now.
+- `CRON_SECRET` may have drifted between droplet `.env` and GitHub secret — verify post-merge.
+- Dependabot queue: 7 PRs from Apr 23 sprint may have grown stale; rerun `npm audit`.
+
+### Forward-plan items unblocked by this fix
+- M1 lint+test ratchet (was blocked because pre-merge tests were unreliable while QR-trap lurked).
+- The 8pm IST daily-report cron now has a clear path back to a connected WhatsApp.
+
+### Vanta invariant captured (for `/vanta-sync` after merge)
+> **Bind-mounted Baileys auth dir + best-effort `wipeAuthDir()` = QR-trap on every loggedOut.** Persistent auth volumes need either: (a) EBUSY-retry + per-file unlink fallback in the wipe, (b) auto-retry-once on loggedOut so user-perceived recovery is single-click, (c) a connect-timeout watchdog because Baileys silently stalls on some 401s without emitting a clean loggedOut. All three layers required; (a) alone leaves user with a two-click recovery path.
+
+---
+
 ## 2026-04-23 — field hotfix sprint + enterprise CI + local act + retro
 
 ### Shipped

--- a/src/app/connect/page.tsx
+++ b/src/app/connect/page.tsx
@@ -26,6 +26,11 @@ export default function ConnectPage() {
   const [processing, setProcessing] = useState(false)
   const [processResult, setProcessResult] = useState<{ visits: number; alerts: number } | null>(null)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  // If the user sits in 'connecting' for >15s the server is almost certainly
+  // jammed (stale auth dir, dead handshake). The lib auto-retries once on its
+  // own; this is the user-visible escape hatch when even that didn't resolve.
+  const [showForceReset, setShowForceReset] = useState(false)
+  const [resetting, setResetting] = useState(false)
 
   const [uploadState, setUploadState] = useState<UploadState>('idle')
   const [uploadResult, setUploadResult] = useState<{ visits: number; alerts: number } | null>(null)
@@ -63,6 +68,18 @@ export default function ConnectPage() {
     return () => { if (pollRef.current) clearInterval(pollRef.current) }
   }, [pollStatus])
 
+  // Show the "Force reset" escape hatch if we've been stuck connecting for 15s.
+  // The lib has its own 10s auto-retry, so by 15s either auto-retry succeeded
+  // (waStatus moved to qr_ready) or it's exhausted and the user needs to step in.
+  useEffect(() => {
+    if (waStatus !== 'connecting') {
+      setShowForceReset(false)
+      return
+    }
+    const t = setTimeout(() => setShowForceReset(true), 15_000)
+    return () => clearTimeout(t)
+  }, [waStatus])
+
   const handleConnect = async () => {
     setWaStatus('connecting')
     setWaError(null)
@@ -77,11 +94,34 @@ export default function ConnectPage() {
 
   const handleDisconnect = async () => {
     await fetch('/api/whatsapp/disconnect', { method: 'POST' })
+    if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null }
     setWaStatus('disconnected')
     setQrDataUrl(null)
     setGroupsError(null)
     setGroups([])
     setGroupsLoaded(false)
+  }
+
+  // Server-side force reset for the QR-trap stuck state. Calls disconnect()
+  // which wipes auth + clears all timers, then immediately re-enters connect
+  // so the user sees one continuous flow instead of having to click twice.
+  const handleForceReset = async () => {
+    setResetting(true)
+    setWaError(null)
+    try {
+      await fetch('/api/whatsapp/disconnect', { method: 'POST' })
+      if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null }
+      setShowForceReset(false)
+      setQrDataUrl(null)
+      // Brief settle for the server-side state machine before re-entering connect.
+      await new Promise((r) => setTimeout(r, 300))
+      await handleConnect()
+    } catch (e) {
+      setWaStatus('failed')
+      setWaError(e instanceof Error ? e.message : 'Force reset failed')
+    } finally {
+      setResetting(false)
+    }
   }
 
   const handleLoadGroups = async () => {
@@ -306,9 +346,21 @@ export default function ConnectPage() {
           )}
 
           {waStatus === 'connecting' && (
-            <div className="text-center py-4">
+            <div className="text-center py-4 space-y-3">
               <RefreshCw size={22} className="animate-spin mx-auto text-amber-400" />
               <p className="text-xs text-zinc-400 mt-2">Starting WhatsApp...</p>
+              {showForceReset && (
+                <div className="space-y-2 pt-2 border-t border-zinc-800">
+                  <p className="text-xs text-zinc-500">Stuck? Stale credentials may be jamming the connection.</p>
+                  <button
+                    onClick={handleForceReset}
+                    disabled={resetting}
+                    className="text-xs font-medium text-amber-400 hover:text-amber-300 underline disabled:opacity-50"
+                  >
+                    {resetting ? 'Resetting...' : 'Force reset and try again'}
+                  </button>
+                </div>
+              )}
             </div>
           )}
 

--- a/src/lib/whatsapp-baileys.ts
+++ b/src/lib/whatsapp-baileys.ts
@@ -17,7 +17,7 @@ import makeWASocket, {
 } from '@whiskeysockets/baileys'
 import QRCode from 'qrcode'
 import path from 'node:path'
-import { rm } from 'node:fs/promises'
+import { rm, readdir, unlink } from 'node:fs/promises'
 import type { RawMessage } from '@/types'
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -152,10 +152,28 @@ function formatErr(err: unknown): string {
 }
 
 async function wipeAuthDir(): Promise<void> {
+  // Try rm -rf first; if the directory is EBUSY (Baileys still holds file
+  // handles from the last creds.update write), fall back to unlinking each
+  // file individually — Linux allows unlink on open files.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await rm(AUTH_DIR, { recursive: true, force: true })
+      return
+    } catch (e: unknown) {
+      const code = (e as NodeJS.ErrnoException).code
+      if (code !== 'EBUSY' || attempt === 2) {
+        console.warn('[Baileys] Failed to wipe auth dir:', formatErr(e))
+        return
+      }
+      await new Promise((r) => setTimeout(r, 300 * (attempt + 1)))
+    }
+  }
+  // Last-resort: unlink individual files, leave the empty dir
   try {
-    await rm(AUTH_DIR, { recursive: true, force: true })
-  } catch (e) {
-    console.warn('[Baileys] Failed to wipe auth dir:', formatErr(e))
+    const files = await readdir(AUTH_DIR)
+    await Promise.all(files.map((f) => unlink(path.join(AUTH_DIR, f)).catch(() => {})))
+  } catch {
+    // directory may not exist — that's fine
   }
 }
 

--- a/src/lib/whatsapp-baileys.ts
+++ b/src/lib/whatsapp-baileys.ts
@@ -50,6 +50,14 @@ interface BaileysState {
   historicalByJid: Map<string, RawMessage[]>
   historySyncProgress: number // 0–100, last value from Baileys
   historySyncComplete: boolean
+  // Auto-recovery from stale-creds traps. Set true when we silently retry after
+  // a loggedOut wipe or a connect-timeout wipe; reset on successful 'open' or
+  // explicit disconnect(). Caps the auto-retry at one per session so a hard
+  // failure surfaces to the user instead of looping invisibly.
+  autoRetriedThisSession: boolean
+  // Fires if we sit in 'connecting' with no QR for too long (stale creds that
+  // don't trigger a clean loggedOut event — Baileys can stall on certain 401s).
+  connectTimeoutTimer: ReturnType<typeof setTimeout> | null
 }
 
 const AUTH_DIR = path.join(process.cwd(), '.baileys_auth')
@@ -110,7 +118,14 @@ const state: BaileysState = {
   historicalByJid: new Map(),
   historySyncProgress: 0,
   historySyncComplete: false,
+  autoRetriedThisSession: false,
+  connectTimeoutTimer: null,
 }
+
+// If we sit in 'connecting' with no QR after this long, assume stale creds are
+// jamming the handshake (Baileys doesn't always emit a clean loggedOut on 401)
+// and self-heal by wiping + retrying once.
+const CONNECT_TIMEOUT_MS = 10_000
 
 // ── Pure helpers ─────────────────────────────────────────────────────────────
 
@@ -182,6 +197,43 @@ function clearReconnectTimer(): void {
     clearTimeout(state.reconnectTimer)
     state.reconnectTimer = null
   }
+}
+
+function clearConnectTimeout(): void {
+  if (state.connectTimeoutTimer) {
+    clearTimeout(state.connectTimeoutTimer)
+    state.connectTimeoutTimer = null
+  }
+}
+
+// Arm the no-progress watchdog. Fires only if we're still in 'connecting'
+// with no QR after CONNECT_TIMEOUT_MS — meaning Baileys stalled silently,
+// almost always due to stale creds that didn't trigger a clean loggedOut.
+function armConnectTimeout(): void {
+  clearConnectTimeout()
+  state.connectTimeoutTimer = setTimeout(() => {
+    state.connectTimeoutTimer = null
+    if (state.shuttingDown) return
+    if (state.qrDataUrl || state.status === 'connected') return
+    if (state.status !== 'connecting') return
+
+    if (state.autoRetriedThisSession) {
+      // Already gave it a clean retry; don't loop forever. Surface to UI.
+      state.status = 'failed'
+      state.error = 'WhatsApp connect timed out. Click Disconnect to force reset, then Connect again.'
+      console.warn('[Baileys] Connect timeout — auto-retry exhausted, surfacing failure')
+      teardownSocket()
+      return
+    }
+
+    console.log('[Baileys] Connect timeout — wiping auth and retrying once (stale-creds self-heal)')
+    state.autoRetriedThisSession = true
+    teardownSocket()
+    // Wipe + reconnect. Status stays 'connecting' so the UI keeps its single
+    // spinner — user experience is one click → one QR, with this happening
+    // invisibly underneath.
+    void wipeAuthDir().then(() => scheduleReconnect(200))
+  }, CONNECT_TIMEOUT_MS)
 }
 
 function teardownSocket(): void {
@@ -295,6 +347,7 @@ async function openSocket(): Promise<{ status: BaileysStatus; error?: string }> 
     sock.ev.on('messages.upsert', handleMessagesUpsert)
     sock.ev.on('messaging-history.set', handleHistorySet)
 
+    armConnectTimeout()
     return { status: state.status }
   } catch (e) {
     const msg = formatErr(e)
@@ -312,6 +365,8 @@ async function handleConnectionUpdate(update: BaileysEventMap['connection.update
     try {
       state.qrDataUrl = await QRCode.toDataURL(qr, { width: 280, margin: 2 })
       state.status = 'qr_ready'
+      // QR arrived — handshake is healthy, no need to watchdog any further.
+      clearConnectTimeout()
       console.log('[Baileys] QR ready — scan with your phone')
     } catch (e) {
       console.error('[Baileys] QR generation error:', formatErr(e))
@@ -324,6 +379,10 @@ async function handleConnectionUpdate(update: BaileysEventMap['connection.update
     state.error = null
     state.lastConnectedAt = Date.now()
     state.reconnectAttempts = 0
+    // Successful open clears the auto-retry budget — a future loggedOut starts
+    // with a fresh single-shot retry, not "we already tried once long ago".
+    state.autoRetriedThisSession = false
+    clearConnectTimeout()
     console.log('[Baileys] Connected')
     return
   }
@@ -356,7 +415,27 @@ async function handleConnectionUpdate(update: BaileysEventMap['connection.update
       // Phone unlinked the device, OR we just called logout(). Either way,
       // creds are now invalid — wipe them so the next connect() generates a
       // fresh QR instead of looping on stale creds.
+      clearConnectTimeout()
       await wipeAuthDir()
+
+      // Self-heal: if this is the first loggedOut this session, the user
+      // hasn't been told yet. Silently re-connect with the now-empty auth dir
+      // so they see "connecting..." → QR, instead of "connecting..." →
+      // "logged out, click again" → "connecting..." → QR (two clicks).
+      if (!state.autoRetriedThisSession) {
+        state.autoRetriedThisSession = true
+        state.qrDataUrl = null
+        state.error = null
+        state.monitoredGroupJid = null
+        state.monitoredGroupName = null
+        console.log('[Baileys] Logged out — auto-retrying once with fresh creds')
+        // 500ms gives Baileys a beat to release any remaining file handles
+        // before the next useMultiFileAuthState reads from the dir.
+        void scheduleReconnect(500)
+        return
+      }
+
+      // Auto-retry already used — surface the loggedOut to the user.
       state.status = 'disconnected'
       state.qrDataUrl = null
       state.error = 'Logged out from WhatsApp. Click Connect to scan a new QR.'
@@ -438,6 +517,7 @@ export async function disconnect(): Promise<void> {
   state.shuttingDown = true
   try {
     clearReconnectTimer()
+    clearConnectTimeout()
 
     // 1. Wait for any in-flight connect() to finish, otherwise its socket would
     //    survive our teardown and become a phantom connection.
@@ -491,6 +571,8 @@ export async function disconnect(): Promise<void> {
     state.historicalByJid = new Map()
     state.historySyncProgress = 0
     state.historySyncComplete = false
+    // Fresh user-initiated session — restore the single-shot auto-retry budget.
+    state.autoRetriedThisSession = false
   } finally {
     state.shuttingDown = false
   }


### PR DESCRIPTION
## Summary

Fixes the QR-not-loading bug on `/connect`. Diagnosis: stale credentials in `.baileys_auth` survive container rebuilds (bind-mounted volume), and the original `wipeAuthDir()` silently fails on EBUSY when Baileys still holds file handles from in-flight `creds.update` writes. The user gets trapped in an invisible 401 loop with no QR ever shown.

The fix is **self-healing** — no manual SSH or operator intervention required. Three layers of defense:

1. **EBUSY-safe `wipeAuthDir()`** (cherry-pick of #042e072, originally on a sibling branch but never merged to main): retries `rm -rf` 3x with backoff, then falls back to per-file `unlink` (Linux allows unlink on open files).

2. **Auto-retry on loggedOut**: after a successful wipe, the lib silently re-enters `connect()` once per session. User clicks Connect ONCE → sees "connecting..." → QR. No second click required.

3. **Connect-timeout watchdog**: if Baileys stalls in 'connecting' for >10s with no QR (some 401s don't trigger a clean `loggedOut`), the lib wipes + retries once. Same single-click experience.

4. **UI escape hatch**: after 15s in 'connecting' (5s past the lib's auto-retry budget), the user sees a "Force reset and try again" link that calls `disconnect()` + re-enters `connect()` server-side. Defense-in-depth for any future failure mode the lib doesn't catch.

The auto-retry is capped at one per session (`autoRetriedThisSession` flag, reset on `'open'` or explicit `disconnect()`) so a hard failure surfaces to the user instead of looping invisibly.

## Why this matters

The 8pm IST cron sends daily reports to the field team via WhatsApp. A stuck `/connect` blocks pairing → cron has no socket → no reports get sent. CONTINUE.md flagged "Reconnect WhatsApp" as a recurring chore after every deploy — this fix closes that loop.

## Commits

- `5ba159e` cherry-pick: EBUSY retry on wipeAuthDir (originally May 1)
- `35d3dc3` self-heal: auto-retry on loggedOut + connect-timeout watchdog
- `604b947` ui: force-reset escape hatch + fix poll-interval leak in handleDisconnect

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 48/48 pass (no regression)
- [x] `npm run build` — `/connect` route builds (5.9 kB, +1.5 kB for force-reset state)
- [ ] Post-deploy: hit https://sales.telligences.com/connect, click Connect on a stale auth dir → confirm QR appears within ~3s without manual rm
- [ ] Verify the force-reset button surfaces if the lib's auto-retry doesn't resolve (would need to inject a stuck state to test deliberately)

## Out-of-scope (follow-up)

- Switch `./baileys_auth:/app/.baileys_auth` from bind mount to named volume (architectural hardening, separate PR)
- Add unit tests for the auto-retry orchestration (would need DI of module-level state — invasive, low ROI)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bajajvinamr/codesmith/sales-agent-publisher/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->