### PR TITLE
fix: bind-mount-safe wipeAuthDir — definitive QR-trap fix + heavy logging

### DIFF
--- a/src/app/api/whatsapp/connect/route.ts
+++ b/src/app/api/whatsapp/connect/route.ts
@@ -2,17 +2,21 @@ import { NextResponse } from 'next/server'
 import { connect, getStatus } from '@/lib/whatsapp-baileys'
 
 export async function POST() {
+  console.log('[api/whatsapp/connect] POST')
   try {
     const result = await connect()
+    console.log(`[api/whatsapp/connect] POST result status=${result.status}${result.error ? ` error=${result.error}` : ''}`)
     return NextResponse.json(result)
   } catch (error) {
-    return NextResponse.json(
-      { status: 'failed', error: error instanceof Error ? error.message : 'Unknown error' },
-      { status: 500 }
-    )
+    const msg = error instanceof Error ? error.message : 'Unknown error'
+    console.error(`[api/whatsapp/connect] POST threw: ${msg}`)
+    return NextResponse.json({ status: 'failed', error: msg }, { status: 500 })
   }
 }
 
 export async function GET() {
-  return NextResponse.json(getStatus())
+  const s = getStatus()
+  // Compact GET log — UI polls every 2s so verbose here would drown actual signal.
+  console.log(`[api/whatsapp/connect] GET status=${s.status} hasQr=${!!s.qrDataUrl}${s.error ? ` error=${s.error}` : ''}`)
+  return NextResponse.json(s)
 }

--- a/src/lib/whatsapp-baileys.ts
+++ b/src/lib/whatsapp-baileys.ts
@@ -17,7 +17,7 @@ import makeWASocket, {
 } from '@whiskeysockets/baileys'
 import QRCode from 'qrcode'
 import path from 'node:path'
-import { rm, readdir, unlink } from 'node:fs/promises'
+import { readdir, unlink } from 'node:fs/promises'
 import type { RawMessage } from '@/types'
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -166,29 +166,79 @@ function formatErr(err: unknown): string {
   return code ? `status=${code}` : String(err)
 }
 
+/**
+ * Wipe Baileys auth dir contents.
+ *
+ * IMPORTANT: AUTH_DIR is a bind-mounted directory in Docker
+ * (`./baileys_auth:/app/.baileys_auth`). The Linux kernel returns EBUSY on any
+ * attempt to `rmdir` a bind mount target while mounted, regardless of file
+ * handles or wait time. So `rm -rf` is the WRONG primitive here — it deletes
+ * contents fine but always fails on the final rmdir of the directory itself.
+ *
+ * The correct approach is per-file `unlink` for the contents. The directory
+ * itself stays (it's the mount point — we don't want to remove it anyway).
+ *
+ * Earlier versions of this function tried `rm -rf` with EBUSY retry, then
+ * fell back to per-file unlink. The fallback was unreachable on the 3rd EBUSY
+ * (logic bug), and rm-rf can never succeed on a bind mount in any case.
+ *
+ * Heavy logging here is intentional — this function has been the prime
+ * suspect in a multi-week QR-trap chase. Logs let us verify, on every call,
+ * that the wipe actually removed files.
+ */
 async function wipeAuthDir(): Promise<void> {
-  // Try rm -rf first; if the directory is EBUSY (Baileys still holds file
-  // handles from the last creds.update write), fall back to unlinking each
-  // file individually — Linux allows unlink on open files.
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      await rm(AUTH_DIR, { recursive: true, force: true })
+  const t0 = Date.now()
+  console.log(`[Baileys.wipe] START dir=${AUTH_DIR}`)
+
+  let files: string[]
+  try {
+    files = await readdir(AUTH_DIR)
+  } catch (e: unknown) {
+    const code = (e as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') {
+      console.log('[Baileys.wipe] dir does not exist — already clean')
       return
+    }
+    console.error(`[Baileys.wipe] readdir failed code=${code}: ${formatErr(e)}`)
+    return
+  }
+
+  console.log(`[Baileys.wipe] found ${files.length} file(s)${files.length ? ': ' + files.slice(0, 5).join(', ') + (files.length > 5 ? ', …' : '') : ''}`)
+
+  let unlinked = 0
+  let failed = 0
+  const failures: string[] = []
+  for (const f of files) {
+    const fp = path.join(AUTH_DIR, f)
+    try {
+      await unlink(fp)
+      unlinked++
     } catch (e: unknown) {
+      failed++
       const code = (e as NodeJS.ErrnoException).code
-      if (code !== 'EBUSY' || attempt === 2) {
-        console.warn('[Baileys] Failed to wipe auth dir:', formatErr(e))
-        return
-      }
-      await new Promise((r) => setTimeout(r, 300 * (attempt + 1)))
+      failures.push(`${f}(${code ?? 'unknown'})`)
     }
   }
-  // Last-resort: unlink individual files, leave the empty dir
+
+  // Verify by re-reading the dir. Anything still here means our wipe failed
+  // for that file specifically — the next connect() will load stale creds
+  // for whatever survived, so we want this surfaced loudly.
+  let survivors: string[] = []
   try {
-    const files = await readdir(AUTH_DIR)
-    await Promise.all(files.map((f) => unlink(path.join(AUTH_DIR, f)).catch(() => {})))
+    survivors = await readdir(AUTH_DIR)
   } catch {
-    // directory may not exist — that's fine
+    /* dir vanished mid-operation — unusual but harmless */
+  }
+
+  const elapsed = Date.now() - t0
+  console.log(
+    `[Baileys.wipe] DONE in ${elapsed}ms — unlinked=${unlinked} failed=${failed} survivors=${survivors.length}`,
+  )
+  if (failed > 0) {
+    console.warn(`[Baileys.wipe] FAILURES: ${failures.join(', ')}`)
+  }
+  if (survivors.length > 0) {
+    console.warn(`[Baileys.wipe] SURVIVORS (next connect will load these as stale creds): ${survivors.slice(0, 5).join(', ')}${survivors.length > 5 ? ', …' : ''}`)
   }
 }
 
@@ -298,14 +348,30 @@ export function clearCapturedMessages(date?: string): void {
 // ── Connect / Disconnect ─────────────────────────────────────────────────────
 
 export async function connect(): Promise<{ status: BaileysStatus; error?: string }> {
+  console.log(
+    `[Baileys.connect] ENTER status=${state.status} autoRetried=${state.autoRetriedThisSession} reconnectAttempts=${state.reconnectAttempts} hasSocket=${!!state.socket} hasConnectingPromise=${!!state.connectingPromise} shuttingDown=${state.shuttingDown}`,
+  )
+
   if (state.shuttingDown) {
+    console.log('[Baileys.connect] EXIT — shutting down')
     return { status: 'disconnected', error: 'Disconnect in progress' }
   }
   if (state.socket && state.status === 'connected') {
+    console.log('[Baileys.connect] EXIT — already connected')
     return { status: 'connected' }
   }
   if (state.connectingPromise) {
+    console.log('[Baileys.connect] EXIT — joining existing connectingPromise')
     return state.connectingPromise
+  }
+
+  // User-initiated calls (POST /api/whatsapp/connect from a fresh state) get
+  // a fresh auto-retry budget. Internal scheduleReconnect calls go through
+  // 'connecting' state, so they don't reset and remain capped at one self-heal.
+  const isUserInitiated = state.status === 'disconnected' || state.status === 'failed'
+  if (isUserInitiated && state.autoRetriedThisSession) {
+    console.log('[Baileys.connect] user-initiated — resetting autoRetriedThisSession')
+    state.autoRetriedThisSession = false
   }
 
   clearReconnectTimer()
@@ -360,6 +426,10 @@ async function openSocket(): Promise<{ status: BaileysStatus; error?: string }> 
 
 async function handleConnectionUpdate(update: BaileysEventMap['connection.update']): Promise<void> {
   const { connection, lastDisconnect, qr } = update
+  const errCode = lastDisconnect?.error ? getStatusCode(lastDisconnect.error) : undefined
+  console.log(
+    `[Baileys.update] connection=${connection ?? 'n/a'} hasQr=${!!qr} errCode=${errCode ?? 'n/a'} status=${state.status} autoRetried=${state.autoRetriedThisSession}`,
+  )
 
   if (qr) {
     try {


### PR DESCRIPTION
## Summary

Definitive fix for the multi-week QR-trap on `/connect`. PR #39 was incomplete; this supersedes it. Single shippable version per contract — no manual SSH ops needed; first user click after deploy triggers self-healing.

## The bug we missed for weeks

Three compounding issues, each subtle alone, devastating together:

1. **Bind mount makes `rm -rf` impossible.** `./baileys_auth:/app/.baileys_auth` — the kernel returns EBUSY on `rmdir` of any active mount target, regardless of file handles or wait time. `rm -rf` deletes contents fine but always fails on the final rmdir of the directory itself. **No amount of retry can succeed.**

2. **The May 1 EBUSY-retry fix (commit `042e072`) has unreachable fallback code.** On the 3rd EBUSY, the catch block `return`s instead of falling through to per-file unlink. So the per-file unlink fallback is dead code — never executed in production.

3. **State-machine leak (introduced in PR #39):** `autoRetriedThisSession` was reset only on explicit `disconnect()`, not on fresh user-initiated `connect()`. After one auto-retry failure, every subsequent click bypassed auto-retry forever (until process restart).

## Why three implementers missed it

Local dev has no bind mount. `rm -rf .baileys_auth` works fine on a regular dir. So local tests pass, code review approves, deploys silently break in production. The `EBUSY` error message suggests "wait and retry" — misleading. The correct interpretation is "wrong primitive."

## Fix

**`wipeAuthDir()` rewritten** to skip `rm -rf` entirely. Per-file `unlink` is the correct primitive for bind-mounted directories — it removes contents, leaves the mount point intact (which is what we want anyway). Post-wipe verification re-reads the dir and logs survivors loudly if any unlinks failed.

**`connect()` resets `autoRetriedThisSession`** when entering from `'disconnected'` or `'failed'` state. Internal `scheduleReconnect` calls go through `'connecting'`, so they still respect the single-shot self-heal cap.

**Heavy logging** at every state transition — `[Baileys.wipe]`, `[Baileys.connect]`, `[Baileys.update]`, and `[api/whatsapp/connect]`. Production logs will now show exactly what happens on each connect attempt.

## Self-healing flow after deploy

```
User clicks Connect (first time after deploy)
  → connect() — status='disconnected', resets autoRetriedThisSession=false
  → openSocket() loads stale creds (still on disk from before)
  → WhatsApp 401 → connection.update connection='close' kind='loggedOut'
  → wipeAuthDir() — per-file unlink succeeds
      [Baileys.wipe] DONE in ~10ms — unlinked=N failed=0 survivors=0
  → autoRetriedThisSession=true, scheduleReconnect(500)
  → openSocket() loads EMPTY creds (this time, actually empty)
  → Baileys emits qr event
  → state.qrDataUrl set, status='qr_ready'
  → UI poll picks up qrDataUrl, renders QR
```

Single click. ~3-5 seconds to QR. No SSH, no manual rm, no operator intervention.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 48/48 (no regression)
- [x] `npm run build` — `/connect` route builds
- [ ] Post-deploy verification (in-browser, NOT just curl):
  - [ ] Visit https://sales.telligences.com/connect
  - [ ] HTTP Basic auth via APP_PASSWORD
  - [ ] Click "Connect WhatsApp" — ONE click only
  - [ ] QR image renders within 5 seconds
  - [ ] Cross-reference container logs: confirm `[Baileys.wipe] DONE ... unlinked=N survivors=0` and `[Baileys] QR ready`
  - [ ] Scan QR with phone, confirm "WhatsApp Connected" status

## Out-of-scope (post-merge invariants)

- Capture in `/vanta-sync`: "Bind-mounted Docker volumes + `rm -rf` = permanent EBUSY. Use per-file `unlink` for cleanup of bind mount contents. Local dev (no bind mount) doesn't reproduce — needs CI test against tmpfs mount target."
- Architectural: consider switching `./baileys_auth` from bind mount to named Docker volume in a future PR (separate concern)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bajajvinamr/codesmith/sales-agent-publisher/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->