### PR TITLE
fix(deploy): localhost health check, bypassing tunnel-cascade

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,17 +85,31 @@ jobs:
       - name: Wait for health
         id: health
         run: |
-          URL="${{ secrets.APP_URL }}/api/health"
-          echo "Polling $URL for up to 3 minutes..."
-          echo "Target URL: $URL"
+          # Probe localhost:3000 from inside the droplet (NOT the public URL)
+          # to bypass the Cloudflare → tunnel → app path. The tunnel can hold
+          # stale TCP cache to the previous app container for an unpredictable
+          # window after a rebuild, returning 503s that look like an app-level
+          # failure but are infrastructure. Localhost goes straight to the
+          # rebuilt container via the host loopback binding in docker-compose.
+          echo "Polling http://localhost:3000/api/health on droplet for up to 3 minutes..."
           # Give app 20s to run prisma push and start Next.js
           sleep 20
           for i in $(seq 1 40); do
-            CODE=$(curl -s -o /tmp/h.json -w "%{http_code}" "$URL" --max-time 8 || echo "000")
+            CODE=$(ssh -i ~/.ssh/id_ed25519 \
+              -o StrictHostKeyChecking=accept-new \
+              -o ConnectTimeout=8 \
+              -o BatchMode=yes \
+              ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+              "curl -s -o /tmp/h.json -w '%{http_code}' http://localhost:3000/api/health --max-time 5 || echo '000'" \
+              2>/dev/null || echo "000")
             echo "Attempt $i: HTTP $CODE"
             if [ "$CODE" = "200" ]; then
               echo "Health OK after ${i} attempt(s)"
-              cat /tmp/h.json
+              ssh -i ~/.ssh/id_ed25519 \
+                -o StrictHostKeyChecking=accept-new \
+                -o BatchMode=yes \
+                ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+                "cat /tmp/h.json" 2>/dev/null || true
               echo ""
               echo "ok=true" >> $GITHUB_OUTPUT
               exit 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,12 @@ services:
     restart: unless-stopped
     expose:
       - "3000"
+    # Bind to host's loopback only — lets deploy.yml health check curl
+    # localhost:3000 from the droplet (bypassing Cloudflare/tunnel which can
+    # return cached 503s during a rebuild). Public traffic still goes through
+    # the tunnel via the docker-internal `app:3000` route, NOT this binding.
+    ports:
+      - "127.0.0.1:3000:3000"
     environment:
       DATABASE_URL: postgresql://postgres:${DB_PASSWORD:-changeme}@db:5432/sales_tracker
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}


### PR DESCRIPTION
## Summary

Deploy infrastructure fix. Unblocks PR #40's merged code from landing on prod.

## Problem

PR #40's deploy was rolled back even though the new app container was healthy. Deploy.yml's health check was going through Cloudflare → tunnel → app, and the tunnel container holds stale TCP cache to the previous app container for an unpredictable window after a rebuild. PR #40's check fired during that window — 40 attempts × HTTP 503 → auto-rollback fired.

PR #39 happened to land in the lucky window where the tunnel cache had already settled. Race condition baked into deploys.

## Fix

Bypass the tunnel for health checks. SSH into the droplet and curl `http://localhost:3000/api/health` from there. Localhost goes straight to the new container via a host-loopback binding.

**docker-compose.yml**: add `ports: ["127.0.0.1:3000:3000"]` to app service. Binds to loopback ONLY (not 0.0.0.0). Public traffic still flows through the tunnel via the docker-internal `app:3000` route. Security posture unchanged.

**deploy.yml Wait for health**: replace `curl ${{ secrets.APP_URL }}/...` with `ssh droplet "curl http://localhost:3000/..."`. Adds ~50ms per attempt for the SSH round-trip — well under the 5s timeout budget.

## After this merges

Once merged, deploy.yml will redeploy the latest main commit (which is `188b9db` from PR #40). The new health check probes the actual new container, not whatever the tunnel points at. The merged QR-trap fix from PR #40 will land successfully.

## Test plan

- [x] `docker compose config` resolves cleanly with `host_ip: 127.0.0.1`
- [x] deploy.yml is valid YAML
- [ ] Post-merge: deploy.yml runs successfully, health check passes via localhost
- [ ] Verify QR-trap fix (PR #40 code) actually works when user clicks Connect — read container logs for `[Baileys.wipe] DONE survivors=0` and confirm QR renders in browser

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bajajvinamr/codesmith/sales-agent-publisher/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->