### PR TITLE
fix(middleware): HTML response on 401 to fix mobile download bug

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -62,9 +62,34 @@ export function middleware(req: NextRequest) {
     }
   }
 
-  return new NextResponse("Unauthorized", {
+  // HTML body (not text/plain) so mobile browsers render the auth challenge
+  // inline. With text/plain, iOS Safari + some Android browsers turn the
+  // unknown-extension URL (/connect, /report, etc.) into a download named
+  // `connect.txt` when the user dismisses or doesn't see the Basic prompt.
+  const body = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sign in — Sales Tracker</title>
+<style>
+body{font-family:system-ui,-apple-system,sans-serif;background:#18181b;color:#e4e4e7;margin:0;padding:2rem;display:flex;align-items:center;justify-content:center;min-height:100vh}
+.box{max-width:24rem;text-align:center}
+h1{margin:0 0 0.5rem;font-size:1.25rem}
+p{margin:0;color:#a1a1aa;font-size:0.875rem;line-height:1.5}
+</style>
+</head>
+<body>
+<div class="box">
+<h1>Sales Tracker</h1>
+<p>This area requires the team password. Your browser should prompt you for it — if not, refresh the page.</p>
+</div>
+</body>
+</html>`
+  return new NextResponse(body, {
     status: 401,
     headers: {
+      "Content-Type": "text/html; charset=utf-8",
       "WWW-Authenticate": 'Basic realm="Sales Tracker"',
     },
   });


### PR DESCRIPTION
## Summary

User report: opening https://sales.telligences.com/connect on iOS Safari downloads a file named `connect.txt` instead of showing the page.

## Cause

`src/middleware.ts:65` returned a `text/plain` body on 401. Mobile browsers (iOS Safari, some Android Chrome) interpret text/plain content from a path with no file extension as a downloadable file when the WWW-Authenticate prompt is dismissed or doesn't appear. Desktop browsers handle this fine; mobile browsers' fallback paths don't.

## Fix

Return an HTML body (small inline-styled page) with `Content-Type: text/html`. WWW-Authenticate header is preserved so Basic auth prompt still fires; the HTML is the fallback that mobile browsers render instead of treating as a download.

## Test plan

- [x] `npm test` — 48/48 pass (no regression)
- [x] `npm run build` — middleware builds, 34 kB
- [ ] Post-deploy: open `/connect` on iPhone Safari → should see HTML page + Basic auth prompt, NOT a download

## Out-of-scope

- Replace HTTP Basic with proper login form (better UX, separate concern)
- Add CSRF protection (separate concern)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bajajvinamr/codesmith/sales-agent-publisher/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->